### PR TITLE
Improvements for MixPanel init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # Misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@types/mixpanel-browser": "^2.60.0",
         "cspell": "^8.17.3",
         "dotenv": "^17.2.0",
+        "dotenv-cli": "^9.0.0",
         "npm-run-all": "^4.1.5",
         "raw-loader": "^4.0.2",
         "tsx": "^4.19.4",
@@ -13834,6 +13835,32 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-cli": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-9.0.0.tgz",
+      "integrity": "sha512-NhGrQum/u1VTBxnSnlNwVkTP3gojYO8T6Fntyru93wbR1hPo8aFhDFJiBPmkT0771i7f5Rd7EQDaOreS8jY8gA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "dotenv": "^17.1.0",
+        "dotenv-expand": "^10.0.0",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "dotenv": "cli.js"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
+      "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "run-p build:jobs-api-ref && DOTENV_CONFIG_PATH=.env.local node -r dotenv/config node_modules/.bin/docusaurus start",
-    "build": "run-p build:jobs-api-ref && DOTENV_CONFIG_PATH=.env.local node -r dotenv/config node_modules/.bin/docusaurus build",
+    "start": "run-p build:jobs-api-ref && dotenv -e .env -e .env.local node_modules/.bin/docusaurus start",
+    "build": "run-p build:jobs-api-ref && dotenv -e .env -e .env.local node_modules/.bin/docusaurus build",
     "build:jobs-spec": "tsx scripts/generate-batch-spec.ts",
     "build:jobs-api-ref": "rm -rf docs/api-ref/jobs && npm run build:jobs-spec && docusaurus gen-api-docs jobs",
     "swizzle": "docusaurus swizzle",
@@ -49,6 +49,7 @@
     "@types/mixpanel-browser": "^2.60.0",
     "cspell": "^8.17.3",
     "dotenv": "^17.2.0",
+    "dotenv-cli": "^9.0.0",
     "npm-run-all": "^4.1.5",
     "raw-loader": "^4.0.2",
     "tsx": "^4.19.4",

--- a/src/components/MixpanelProvider.tsx
+++ b/src/components/MixpanelProvider.tsx
@@ -36,7 +36,8 @@ export default function MixpanelProvider({ children }) {
 
   useEffect(() => {
     // Only run on client-side and if Mixpanel is initialized
-    if (typeof window === "undefined" || !mixpanel) {
+    if (!token) {
+      console.warn("MixPanel couldn't be initialized");
       return;
     }
 
@@ -47,7 +48,7 @@ export default function MixpanelProvider({ children }) {
       // User has not consented or opted out of statistics tracking
       mixpanel.opt_out_tracking();
     }
-  }, [statistics]);
+  }, [statistics, token]);
 
   return <>{children}</>;
 }


### PR DESCRIPTION
- Accept both `.env` and `.env.local` files for loading env vars
- Don't crash if MixPanel token is not found