### PR TITLE
Remove super property 'event_source' as it's value is overwritten whe…

### DIFF
--- a/src/components/MixpanelProvider.tsx
+++ b/src/components/MixpanelProvider.tsx
@@ -46,8 +46,7 @@ const MixpanelTracker = React.memo(
           capture_text_content: false,
         },
       });
-    }
-  }, [token]);
+    }, [token, mixpanel]);
 
     // Handle user consent - only runs when consent changes
     useEffect(() => {


### PR DESCRIPTION
Remove super-property `event_source` as it's overwritten by other mixpanel sdks in different subdomains