### PR TITLE
Update mid-session config to include end of utterance and volume threshold

### DIFF
--- a/spec/realtime.yaml
+++ b/spec/realtime.yaml
@@ -114,6 +114,8 @@ components:
         - `max_delay`
         - `max_delay_mode`
         - `enable_partials`
+        - `volume_threshold`
+        - `end_of_utterance_silence_trigger`
 
         If you wish to alter any other parameters you must terminate the session and restart with the altered configuration. Attempting otherwise will result in an error.
 


### PR DESCRIPTION
Updating the guidance in the docs for config supported for mid-session changes (in SetRecognitionConfig) to include:
- volume_threshold
- end_of_utterance_silence_trigger

Note - this MR won't be merged until the code changes have been released.