### PR TITLE
Update docs for multichannel limitations

### DIFF
--- a/docs/api-ref/realtime-transcription-websocket.mdx
+++ b/docs/api-ref/realtime-transcription-websocket.mdx
@@ -40,6 +40,8 @@ sequenceDiagram
   loop Audio Stream
     Client->>API: AddAudio
     API-->>Client: AudioAdded
+    Client->>API: AddChannelAudio (optional)
+    API-->>Client: ChannelAudioAdded (optional)
     API-->>Client: AddPartialTranscript (optional)
     API-->>Client: AddTranscript (optional)
   end

--- a/docs/speech-to-text/realtime/realtime_diarization.mdx
+++ b/docs/speech-to-text/realtime/realtime_diarization.mdx
@@ -174,7 +174,10 @@ Transcripts are returned independently for each channel, with the `channel` prop
 }
 ```
 
-Note that the `channel` property will be returned for `AddTranscript` and `AddPartialTranscript` messages only. Features such as [audio events](/speech-to-text/features/audio-events) do not currently include this property. To request this feature, please contact [support](https://support.speechmatics.com).
+:::warning
+The `channel` property will be returned for `AddTranscript` and `AddPartialTranscript` messages only. 
+Features such as [audio events](/speech-to-text/features/audio-events), [translation](/speech-to-text/features/translation) and [end of turn detection](/speech-to-text/features/end-of-turn) do not currently include this property. To request this feature, please contact [support](https://support.speechmatics.com).
+:::
 
 ### Channel and speaker diarization
 
@@ -220,6 +223,8 @@ Transcripts are returned in the same way as channel diarization, but with indivi
 For SaaS customers, the maximum number of channels is 2.
 
 For On-prem Container customers, the maximum number of channels depends on your [Multi-session container's](../../deployments/container/cpu-speech-to-text.mdx#multi-session-containers) maximum number of connections.
+
+
 
 ## Configuration
 

--- a/docs/speech-to-text/realtime/realtime_diarization.mdx
+++ b/docs/speech-to-text/realtime/realtime_diarization.mdx
@@ -178,13 +178,11 @@ Note that the `channel` property will be returned for `AddTranscript` and `AddPa
 
 ### Channel and speaker diarization
 
-Channel and speaker diarization combines speaker diarization and shannel diarization, splitting transcripts per channel whilst also separating individual speakers in each channel.
+Channel and speaker diarization combines speaker diarization and channel diarization, splitting transcripts per channel whilst also separating individual speakers in each channel.
 
 To enable this mode, follow the steps in [speaker diarization](#speaker-diarization) and set the `diarization` mode to `channel_and_speaker`.
 
 To send audio to a channel, follow the instructions in [send audio to a channel](#send-audio-to-a-channel). 
-
-To send audio to a specific channel, follow the directions for [sending audio to a channel](#send-audio-to-a-channel).
 
 Transcripts are returned in the same way as channel diarization, but with individual speakers identified:
 

--- a/docs/speech-to-text/realtime/realtime_diarization.mdx
+++ b/docs/speech-to-text/realtime/realtime_diarization.mdx
@@ -218,13 +218,16 @@ Transcripts are returned in the same way as channel diarization, but with indivi
   ]
 }
 ```
+
+When using `channel_and_speaker` diarization, speaker labelling is specific to channels even if the speaker labels are the same. S1 on channel 1 is not the same as S1 on channel 2.
+
 ### Limits
 
 For SaaS customers, the maximum number of channels is 2.
 
 For On-prem Container customers, the maximum number of channels depends on your [Multi-session container's](../../deployments/container/cpu-speech-to-text.mdx#multi-session-containers) maximum number of connections.
 
-
+The Speechmatics Python client CLI is currently limited to transcribing multi-channel audio in via files and not streaming/raw audio. 
 
 ## Configuration
 

--- a/spec/realtime.yaml
+++ b/spec/realtime.yaml
@@ -360,6 +360,9 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/RecognitionResult"
+        channel:
+          type: string
+          description: The channel identifier to which the audio belongs. Only used with multichannel diarization.
       required:
         - message
         - metadata
@@ -379,6 +382,9 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/RecognitionResult"
+        channel:
+          type: string
+          description: The channel identifier to which the audio belongs. Only used with multichannel diarization.
       required:
         - message
         - metadata
@@ -819,8 +825,6 @@ components:
         end_time:
           type: number
           format: float
-        channel:
-          type: string
         attaches_to:
           $ref: "#/components/schemas/AttachesToEnum"
         is_eos:

--- a/spec/realtime.yaml
+++ b/spec/realtime.yaml
@@ -28,6 +28,8 @@ channels:
         $ref: "#/components/messages/StartRecognition"
       AddAudio:
         $ref: "#/components/messages/AddAudio"
+      AddChannelAudio:
+        $ref: "#/components/messages/AddChannelAudio"
       EndOfStream:
         $ref: "#/components/messages/EndOfStream"
       SetRecognitionConfig:
@@ -39,6 +41,8 @@ channels:
         $ref: "#/components/messages/RecognitionStarted"
       AudioAdded:
         $ref: "#/components/messages/AudioAdded"
+      ChannelAudioAdded:
+        $ref: "#/components/messages/ChannelAudioAdded"
       AddPartialTranscript:
         $ref: "#/components/messages/AddPartialTranscript"
       AddTranscript:
@@ -69,6 +73,7 @@ operations:
     messages:
       - $ref: "#/channels/publish/messages/StartRecognition"
       - $ref: "#/channels/publish/messages/AddAudio"
+      - $ref: "#/channels/publish/messages/AddChannelAudio"
       - $ref: "#/channels/publish/messages/EndOfStream"
       - $ref: "#/channels/publish/messages/SetRecognitionConfig"
   subscribe:
@@ -78,6 +83,7 @@ operations:
     messages:
       - $ref: "#/channels/subscribe/messages/RecognitionStarted"
       - $ref: "#/channels/subscribe/messages/AudioAdded"
+      - $ref: "#/channels/subscribe/messages/ChannelAudioAdded"
       - $ref: "#/channels/subscribe/messages/AddPartialTranscript"
       - $ref: "#/channels/subscribe/messages/AddTranscript"
       - $ref: "#/channels/subscribe/messages/AddPartialTranslation"
@@ -120,6 +126,17 @@ components:
         :::
       payload:
         $ref: "#/components/schemas/SetRecognitionConfig"
+    AddChannelAudio:
+      summary: |
+        Adds audio to a specific channel.
+
+        :::note
+
+        **`channel` or `channel_and_speaker` diarization must be enabled to use this.**
+        
+        To learn more about diarization and how to enable it, please visit the [realtime diarization](https://docs.speechmatics.com/speech-to-text/realtime/realtime_diarization) page.
+      payload:
+        $ref: "#/components/schemas/AddChannelAudio"
     RecognitionStarted:
       summary: Server response to StartRecognition, acknowledging that a recognition session has started.
       payload:
@@ -154,6 +171,11 @@ components:
       summary: Contains the final transcript of a part of the audio that the client has sent.
       payload:
         $ref: "#/components/schemas/AddTranscript"
+    ChannelAudioAdded:
+      summary: |
+        Server response to AddChannelAudio, indicating that audio has been added successfully to a specific channel.
+      payload:
+        $ref: "#/components/schemas/ChannelAudioAdded"
     EndOfUtterance:
       summary: |
         Indicates the end of an utterance, triggered by a configurable period of non-speech.
@@ -250,6 +272,21 @@ components:
       required:
         - message
         - last_seq_no
+    AddChannelAudio:
+      type: object
+      properties:
+        message:
+          const: AddChannelAudio
+        channel:
+          type: string
+          description: The channel identifier to which the audio belongs.
+        data:
+          type: string
+          description: The audio data in base64 format
+      required:
+        - message
+        - channel
+        - data
     SetRecognitionConfig:
       type: object
       properties:
@@ -294,6 +331,20 @@ components:
       required:
         - message
         - seq_no
+    ChannelAudioAdded:
+      type: object
+      properties: 
+        message:
+          const: ChannelAudioAdded
+        channel:
+          type: string
+          description: The channel identifier to which the audio belongs
+        seq_no:
+          type: integer
+      required:
+        - message
+        - channel
+        - number
     AddPartialTranscript:
       type: object
       properties:


### PR DESCRIPTION
This change adds in documentation for known multichannel feature limits. Some of these limitations will be covered in time.

Closes off [DEL-25816](https://speechmatics.atlassian.net/browse/DEL-28516).