### PR TITLE
Add missing end of channel message diagram

### DIFF
--- a/docs/api-ref/realtime-transcription-websocket.mdx
+++ b/docs/api-ref/realtime-transcription-websocket.mdx
@@ -45,6 +45,7 @@ sequenceDiagram
     API-->>Client: AddPartialTranscript (optional)
     API-->>Client: AddTranscript (optional)
   end
+  Client->>API: EndOfChannel (optional)
   Client->>API: EndOfStream
   API-->>Client: EndOfTranscript
 ```


### PR DESCRIPTION
Reopening of https://speechmatics.atlassian.net/browse/DEL-28516?focusedCommentId=151335 as this was missing the EndOfChannel message from the flowchart diagram.