### PR TITLE
Fix Pipecat quickstart: correct package extra and service Settings API

### DIFF
--- a/docs/integrations-and-sdks/pipecat/assets/main.py
+++ b/docs/integrations-and-sdks/pipecat/assets/main.py
@@ -36,19 +36,19 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     async with aiohttp.ClientSession() as session:
         stt = SpeechmaticsSTTService(
             api_key=os.getenv("SPEECHMATICS_API_KEY"),
-            params=SpeechmaticsSTTService.InputParams(
+            settings=SpeechmaticsSTTService.Settings(
                 turn_detection_mode=SpeechmaticsSTTService.TurnDetectionMode.EXTERNAL,
             ),
         )
 
         llm = OpenAILLMService(
             api_key=os.getenv("OPENAI_API_KEY"),
-            model="gpt-4o-mini",
+            settings=OpenAILLMService.Settings(model="gpt-4o-mini"),
         )
 
         tts = SpeechmaticsTTSService(
             api_key=os.getenv("SPEECHMATICS_API_KEY"),
-            voice_id="sarah",
+            settings=SpeechmaticsTTSService.Settings(voice="sarah"),
             aiohttp_session=session,
         )
 

--- a/docs/integrations-and-sdks/pipecat/index.mdx
+++ b/docs/integrations-and-sdks/pipecat/index.mdx
@@ -37,7 +37,7 @@ mkdir voice-agent && cd voice-agent
 Create a `requirements.txt` file:
 
 ```text title="requirements.txt"
-pipecat-ai[local-smart-turn-v3,silero,speechmatics,webrtc,openai,runner]
+pipecat-ai[local-smart-turn,silero,speechmatics,webrtc,openai,runner]
 pipecat-ai-small-webrtc-prebuilt
 python-dotenv
 loguru


### PR DESCRIPTION
  Two fixes to the Pipecat quickstart docs, caught during dogfooding:

  index.mdx
  - Changed pipecat-ai[local-smart-turn-v3,...] → pipecat-ai[local-smart-turn,...]
  - The local-smart-turn-v3 extra doesn't exist in the package, causing an install warning

  assets/main.py
  - Updated service initialisation to use the current .Settings() API:
    - SpeechmaticsSTTService: params=InputParams(...) → settings=Settings(...)
    - OpenAILLMService: model="gpt-4o-mini" → settings=Settings(model="gpt-4o-mini")
    - SpeechmaticsTTSService: voice_id="sarah" → settings=Settings(voice="sarah")

  Testing

  Followed the quickstart end-to-end with these changes:
  - Install: clean, no warnings
  - Bot started successfully and reached Uvicorn running on http://localhost:7860
  - No DeprecationWarnings