### PR TITLE
Deprecate `operating_point` in favor of `model` where applicable

### DIFF
--- a/docs/deployments/container/cpu-speech-to-text.mdx
+++ b/docs/deployments/container/cpu-speech-to-text.mdx
@@ -266,7 +266,7 @@ The parameters are:
 
 - `processor` - One of `cpu` or `gpu`. Note that selecting `gpu` requires a [GPU Inference Container](/deployments/container/gpu-speech-to-text)
 
-- `operating_point` - One of `standard` or `enhanced`. The [operating point](/speech-to-text/languages#operating-points) you want to prewarm
+- `operating_point` - One of `standard` or `enhanced`. The [operating point](/speech-to-text/languages#models) you want to prewarm
 
 - `prewarm_connections` - Integer. The number of engine instances of the specific mode you want to pre-warm. The total number of `prewarm_connections` cannot be greater than `SM_MAX_CONCURRENT_CONNECTIONS`. After the pre-warming is complete, this parameter does not limit the types of connections the engine can start.
 

--- a/docs/deployments/container/gpu-speech-to-text.mdx
+++ b/docs/deployments/container/gpu-speech-to-text.mdx
@@ -107,7 +107,7 @@ Once the GPU Server is running, follow the [Instructions for Linking a CPU Conta
 
 ### Running only one operating point
 
-[Operating Points](/speech-to-text/languages#operating-points) represent different levels of model complexity.
+[Operating Points](/speech-to-text/languages#models) represent different levels of model complexity.
 To save GPU memory for throughput, you can run the server with only one Operating Point loaded. To do this, pass the
 `SM_OPERATING_POINT` environment variable to the container and set it to either `standard` or `enhanced`.
 

--- a/docs/integrations-and-sdks/vapi.mdx
+++ b/docs/integrations-and-sdks/vapi.mdx
@@ -61,7 +61,7 @@ print(f"Assistant ID: {assistant.id}")
 
 ### Best practices
 
-- **Operating point**: Select the enhanced model for the best accuracy in real-time voice agents.
+- **Model**: Select the enhanced model for the best accuracy in real-time voice agents.
 - **Region**: Choose the region closest to optimize latency.
 - **Custom vocabulary**: add key terms (e.g., product names, medical terminology) and leverage the "sounds like" option for tricky pronunciations.
 

--- a/docs/private/next-gen-model.mdx
+++ b/docs/private/next-gen-model.mdx
@@ -35,7 +35,7 @@ Example minimal transcription config:
   "transcription_config": {
     // highlight-start
     "language": "multi",
-    "operating_point": "omni-v1",
+    "model": "melia-1",
     // highlight-end
   }
 }
@@ -50,7 +50,7 @@ Example config with language hints:
   "type": "transcription",
   "transcription_config": {
     "language": "multi",
-    "operating_point": "omni-v1",
+    "model": "melia-1",
     // highlight-start
     "language_hints": ["en", "ar"]
     // highlight-end

--- a/docs/speech-to-text/batch/assets/file-transcription-quickstart.py
+++ b/docs/speech-to-text/batch/assets/file-transcription-quickstart.py
@@ -12,7 +12,7 @@ settings = ConnectionSettings(
 )
 
 # Define transcription parameters
-conf = {"type": "transcription", "transcription_config": {"language": LANGUAGE, "operating_point": "enhanced"}}
+conf = {"type": "transcription", "transcription_config": {"language": LANGUAGE, "model": "enhanced"}}
 
 # Open the client using a context manager
 with BatchClient(settings) as client:

--- a/docs/speech-to-text/batch/assets/file-transcription-quickstart.sh
+++ b/docs/speech-to-text/batch/assets/file-transcription-quickstart.sh
@@ -4,4 +4,4 @@ PATH_TO_FILE="example.wav"
 curl -L -X POST "https://eu1.asr.api.speechmatics.com/v2/jobs/" \
 -H "Authorization: Bearer ${API_KEY}" \
 -F data_file=@${PATH_TO_FILE} \
--F config='{"type": "transcription","transcription_config": { "operating_point":"enhanced", "language": "en" }}'
+-F config='{"type": "transcription","transcription_config": { "model":"enhanced", "language": "en" }}'

--- a/docs/speech-to-text/batch/assets/transcript-response-example.json
+++ b/docs/speech-to-text/batch/assets/transcript-response-example.json
@@ -18,7 +18,7 @@
     "orchestrator_version": "2025.06.28+1eb4127132+13.4.0",
     "transcription_config": {
       "language": "en",
-      "operating_point": "enhanced"
+      "model": "enhanced"
     },
     "type": "transcription"
   },

--- a/docs/speech-to-text/features/audio-events.mdx
+++ b/docs/speech-to-text/features/audio-events.mdx
@@ -33,7 +33,7 @@ If you're new to Speechmatics, start by exploring our guides on [Processing a Fi
 { 
   "type": "transcription", 
   "transcription_config": { 
-    "operating_point": "enhanced", 
+    "model": "enhanced", 
     "language": "en" 
   }, 
   // highlight-start
@@ -272,7 +272,7 @@ An example of a request only for `applause` and `music`
 { 
   "type": "transcription", 
   "transcription_config": { 
-    "operating_point": "enhanced", 
+    "model": "enhanced", 
     "language": "en" 
   }, 
 

--- a/docs/speech-to-text/features/audio-filtering.mdx
+++ b/docs/speech-to-text/features/audio-filtering.mdx
@@ -37,7 +37,7 @@ To activate Audio Filtering, include the following configuration:
         "volume_threshold": 3.4
     },
     "language": "en",
-    "operating_point": "enhanced"
+    "model": "enhanced"
   }
 }
 ```
@@ -73,6 +73,6 @@ To obtain volume labelling without filtering any audio, supply an empty config o
 
 Once the audio is in a raw format (16kHz 16bit mono), it is split into 0.01s chunks. For each chunk, the root mean square amplitude of the signal is calculated, and scaled to the range `0 - 100`. If the volume is less than the supplied cut-off, the chunk will be replaced with silence.
 
-To work successfully without degrading accuracy, the background speech must be significantly quieter than the foreground speech, otherwise the filtering process may remove small sections of the audio which should be transcribed. For this reason, the feature works better with the [Enhanced Operating Points](/speech-to-text/languages#operating-points), which is more robust against inadvertent damage to the audio.
+To work successfully without degrading accuracy, the background speech must be significantly quieter than the foreground speech, otherwise the filtering process may remove small sections of the audio which should be transcribed. For this reason, the feature works better with the [enhanced model](/speech-to-text/languages#operating-points), which is more robust against inadvertent damage to the audio.
 
 The word volume calculation takes the start and end times of words, and applies a weighted average of the volumes of each audio chunk which make up the word. The weighting attempts to ignore areas of silence within long words, and provide a better match with the volume classification a human listener would make.

--- a/docs/speech-to-text/features/speaker-identification.mdx
+++ b/docs/speech-to-text/features/speaker-identification.mdx
@@ -44,8 +44,8 @@ It is recommended to minimize the number of speaker IDs to achieve optimal accur
 
 Speaker identifiers have the following limitations and scoping rules:
 
-- **Model-specific** — Identifiers are tied to the model used to generate them and are valid only within the same operating point. Using identifiers across different operating points is not supported and any such identifiers will be ignored.
-  Whenever a model within an operating point is updated, existing identifiers must always be regenerated.
+- **Model-specific** — Identifiers are tied to the model used to generate them. Using identifiers across different models is not supported and any such identifiers will be ignored.
+  Whenever a model is updated, existing identifiers must always be regenerated.
 
 - **Encrypted and scoped** — Identifiers are securely encrypted and scoped to your account context:
   - **Per customer** — Identifiers are unique to each customer and cannot be shared or reused across customers.

--- a/docs/speech-to-text/features/translation.mdx
+++ b/docs/speech-to-text/features/translation.mdx
@@ -42,7 +42,7 @@ New to Speechmatics? See our guides on [transcribing a file](/speech-to-text/bat
 {
   "type": "transcription",
   "transcription_config": {
-    "operating_point": "enhanced",
+    "model": "enhanced",
     "language": "en"
   },
   // highlight-start
@@ -359,7 +359,7 @@ In batch, you can also translate from Norwegian Bokmål to Nynorsk.
 
 Follow these guidelines to achieve optimal translation results:
 
-- **Use enhanced operating point** — Higher transcription accuracy directly leads to better translations
+- **Use the enhanced model** — Higher transcription accuracy directly leads to better translations
 - **Keep punctuation enabled** — Maintain all [punctuation settings](/speech-to-text/formatting#punctuation) at default levels for optimal translation quality
 - **Consider processing times** — Each additional target language increases processing time in batch jobs
 - **Plan for connection closing** — Realtime sessions may have a 5-second delay when finalizing translations

--- a/docs/speech-to-text/languages.mdx
+++ b/docs/speech-to-text/languages.mdx
@@ -21,7 +21,7 @@ keywords:
     es-pr,
     es-ar,
     pt-br,
-    operating point,
+    model,
     standard,
     enhanced,
   ]
@@ -30,20 +30,20 @@ keywords:
 # Languages and models
 
 
-### Operating points
+### Models {#operating-points}
 
 Choose between two accuracy models when configuring your transcription session:
 - **Standard** — optimized for faster turnaround with strong accuracy. Recommended when speed and efficiency are your priorities
 - **Enhanced** — our highest-accuracy model with strong turnaround times. Recommended when precision is critical, and especially for complex audio (e.g. noisy environments, varied accents)
 
-By default, the `standard` operating point is used. You can specify the `enhanced` operating point as a part of the transcription config. For example:
+By default, the `standard` model is used. You can specify the `enhanced` model as a part of the transcription config. For example:
 ```json
 {
   "type": "transcription",
   "transcription_config": {
     "language": "en",
     // highlight-start
-    "operating_point": "enhanced"    
+    "model": "enhanced"    
     // highlight-end
   }
 }
@@ -190,10 +190,10 @@ Speechmatics offers domain-specific medical transcription models which provide u
 
 These models are kept up to date using officially maintained data sources. This brings significant improvements in recognition of medical terminology such as names of procedures, medications, conditions, and anatomy.
 
-Note that for languages without a medical transcription model, Speechmatics still offers industry-leading accuracy in the healthcare domain when using the general purpose `enhanced` [operating point](#operating-points). 
+Note that for languages without a medical transcription model, Speechmatics still offers industry-leading accuracy in the healthcare domain when using the general purpose `enhanced` [model](#operating-points). 
 
 :::info
-The medical domain-specific model must be used with the `enhanced` operating point.
+The medical domain-specific model must be used with the `enhanced` model.
 :::
  
 Medical domain example:
@@ -203,7 +203,7 @@ Medical domain example:
   "transcription_config": {
     "language": "en",
     // highlight-start
-    "operating_point": "enhanced",
+    "model": "enhanced",
     "domain": "medical"
   // highlight-end
   }

--- a/docs/speech-to-text/languages.mdx
+++ b/docs/speech-to-text/languages.mdx
@@ -30,7 +30,7 @@ keywords:
 # Languages and models
 
 
-### Models {#operating-points}
+### Models
 
 Choose between two accuracy models when configuring your transcription session:
 - **Standard** — optimized for faster turnaround with strong accuracy. Recommended when speed and efficiency are your priorities
@@ -190,7 +190,7 @@ Speechmatics offers domain-specific medical transcription models which provide u
 
 These models are kept up to date using officially maintained data sources. This brings significant improvements in recognition of medical terminology such as names of procedures, medications, conditions, and anatomy.
 
-Note that for languages without a medical transcription model, Speechmatics still offers industry-leading accuracy in the healthcare domain when using the general purpose `enhanced` [model](#operating-points). 
+Note that for languages without a medical transcription model, Speechmatics still offers industry-leading accuracy in the healthcare domain when using the general purpose `enhanced` [model](#models). 
 
 :::info
 The medical domain-specific model must be used with the `enhanced` model.

--- a/docs/speech-to-text/realtime/assets/end-of-utterance-file-example.py
+++ b/docs/speech-to-text/realtime/assets/end-of-utterance-file-example.py
@@ -57,7 +57,7 @@ conversation_config = speechmatics.models.ConversationConfig(
 )  # Adjust as needed
 
 conf = speechmatics.models.TranscriptionConfig(
-    operating_point="enhanced",
+    model="enhanced",
     language=LANGUAGE,
     enable_partials=True,
     max_delay=1,

--- a/docs/speech-to-text/realtime/assets/end-of-utterance-streaming-example.py
+++ b/docs/speech-to-text/realtime/assets/end-of-utterance-streaming-example.py
@@ -103,7 +103,7 @@ class VoiceAITranscriber:
             )  # Adjust as needed
 
             conf = speechmatics.models.TranscriptionConfig(
-                operating_point="enhanced",
+                model="enhanced",
                 language=LANGUAGE,
                 enable_partials=True,
                 max_delay=1,

--- a/docs/speech-to-text/realtime/assets/javascript-radio-example.js
+++ b/docs/speech-to-text/realtime/assets/javascript-radio-example.js
@@ -37,7 +37,7 @@ async function transcribe() {
   await client.start(jwt, {
     transcription_config: {
       language: "en",
-      operating_point: "enhanced",
+      model: "enhanced",
       max_delay: 1.0,
       transcript_filtering_config: {
         remove_disfluencies: true,

--- a/docs/speech-to-text/realtime/assets/microphone-example.py
+++ b/docs/speech-to-text/realtime/assets/microphone-example.py
@@ -96,7 +96,7 @@ ws = speechmatics.client.WebsocketClient(conn)
 conf = speechmatics.models.TranscriptionConfig(
     language=LANGUAGE,
     enable_partials=True,
-    operating_point="enhanced",
+    model="enhanced",
     max_delay=1,
 )
 

--- a/docs/speech-to-text/realtime/assets/url-example.py
+++ b/docs/speech-to-text/realtime/assets/url-example.py
@@ -47,7 +47,7 @@ settings = speechmatics.models.AudioSettings()
 # Define transcription parameters
 # Full list of parameters described here: https://speechmatics.github.io/speechmatics-python/models
 conf = speechmatics.models.TranscriptionConfig(
-    operating_point="enhanced",
+    model="enhanced",
     language=LANGUAGE,
     enable_partials=True,
     max_delay=1,

--- a/docs/speech-to-text/realtime/output.mdx
+++ b/docs/speech-to-text/realtime/output.mdx
@@ -26,7 +26,7 @@ The following example shows a typical configuration for low latency applications
   "type": "transcription",
   "transcription_config": {
     "language": "en",
-    "operating_point": "enhanced",
+    "model": "enhanced",
     // highlight-start
     "max_delay": 0.7,
     "max_delay_mode": "flexible",
@@ -62,7 +62,7 @@ Partial transcripts allow you to receive preliminary transcription and update as
   "type": "transcription",
   "transcription_config": {
     "language": "en",
-    "operating_point": "enhanced",
+    "model": "enhanced",
     "max_delay": 2,
     // highlight-start
     "enable_partials": true,

--- a/docs/speech-to-text/realtime/realtime-diarization.mdx
+++ b/docs/speech-to-text/realtime/realtime-diarization.mdx
@@ -307,7 +307,7 @@ You can prevent too many speakers from being detected by using the `max_speakers
   },
   "transcription_config": {
     "language": "en",
-    "operating_point": "enhanced",
+    "model": "enhanced",
     // highlight-start
     "diarization": "speaker",
     "speaker_diarization_config": {

--- a/spec/batch.yaml
+++ b/spec/batch.yaml
@@ -504,13 +504,13 @@ paths:
                 - mode: batch
                   type: transcription
                   language: sv
-                  operating_point: standard
+                  model: standard
                   count: 4
                   duration_hrs: 1.33
                 - mode: batch
                   type: transcription
                   language: de
-                  operating_point: enhanced
+                  model: enhanced
                   count: 1
                   duration_hrs: 0.2
                 - mode: batch

--- a/spec/batch.yaml
+++ b/spec/batch.yaml
@@ -699,7 +699,7 @@ definitions:
         $ref: "#/definitions/OperatingPoint"
         deprecated: true
         description: |-
-          **Deprecated**: Use `model` instead. `operating_point` is left only for backward compatibility for `standard` and `enhanced`.
+          **Deprecated**: Use `model` instead. `operating_point` is left only for backward compatibility.
       additional_vocab:
         type: array
         x-omitempty: true
@@ -1400,8 +1400,6 @@ definitions:
         items:
           $ref: "#/definitions/AutoChaptersResultError"
         description: List of errors that occurred in the auto chapters stage.
-      alignment_config:
-        $ref: "#/definitions/AlignmentConfig"
       output_config:
         $ref: "#/definitions/OutputConfig"
       language_pack_info:

--- a/spec/batch.yaml
+++ b/spec/batch.yaml
@@ -7,10 +7,19 @@ info:
   contact:
     email: support@speechmatics.com
 basePath: /v2
+schemes:
+  - https
 produces:
   - application/json
-  # users are using this header for Accept get job and delete job REQ-17778
   - application/vnd.speechmatics.v2+json
+securityDefinitions:
+  bearerAuth:
+    type: apiKey
+    in: header
+    name: Authorization
+    description: "Bearer token authentication. Use the format: Bearer <api_key/jwt>"
+security:
+  - bearerAuth: []
 paths:
   "/jobs":
     post:
@@ -22,7 +31,7 @@ paths:
           in: formData
           type: string
           description: >-
-            JSON containing a [`JobConfig`](/speech-to-text/batch/input#jobconfig-schema) model indicating the type and parameters for the recognition job.
+            JSON containing a `JobConfig` model indicating the type and parameters for the recognition job.
           required: true
         - name: data_file
           in: formData
@@ -37,11 +46,7 @@ paths:
           description: >-
             **Note**: Only available for on-prem
 
-            JSON dictionary of processing settings for the job worker.
-            Currently supports `parallel_engines` (integer), which controls
-            the number of engines the worker can use in parallel for this job, and
-            `user_id` (string), which is the user id for this job.
-            Example: `{"parallel_engines": 4}`
+            JSON dictionary of processing settings for the job worker. Currently supports `parallel_engines` (integer), which controls the number of engines the worker can use in parallel for this job, and `user_id` (string), which is the user id for this job. Example: `{"parallel_engines": 4}`
       responses:
         "201":
           description: OK
@@ -133,6 +138,8 @@ paths:
             application/json:
               code: 422
               error: limit in query must be of type int64
+        "429":
+          description: Rate Limited
         "500":
           description: Internal Server Error
           schema:
@@ -181,6 +188,8 @@ paths:
             application/json:
               code: 410
               error: Job Expired
+        "429":
+          description: Rate Limited
         "500":
           description: Internal Server Error
           schema:
@@ -242,6 +251,8 @@ paths:
             application/json:
               code: 423
               error: Resource Locked
+        "429":
+          description: Rate Limited
         "500":
           description: Internal Server Error
           schema:
@@ -378,6 +389,8 @@ paths:
               code: 410
               error: File Expired
               detail: File deleted from the storage
+        "429":
+          description: Rate Limited
         "500":
           description: Internal Server Error
           schema:
@@ -433,6 +446,8 @@ paths:
               code: 410
               error: File Expired
               detail: File deleted from the storage
+        "429":
+          description: Rate Limited
         "500":
           description: Internal Server Error
           schema:
@@ -472,6 +487,37 @@ paths:
           description: OK
           schema:
             $ref: "#/definitions/UsageResponse"
+          examples:
+            application/json:
+              since: "2021-09-12T00:00:00Z"
+              until: "2022-01-01T23:59:59Z"
+              summary:
+                - mode: batch
+                  type: transcription
+                  count: 5
+                  duration_hrs: 1.53
+                - mode: batch
+                  type: alignment
+                  count: 1
+                  duration_hrs: 0.1
+              details:
+                - mode: batch
+                  type: transcription
+                  language: sv
+                  operating_point: standard
+                  count: 4
+                  duration_hrs: 1.33
+                - mode: batch
+                  type: transcription
+                  language: de
+                  operating_point: enhanced
+                  count: 1
+                  duration_hrs: 0.2
+                - mode: batch
+                  type: alignment
+                  language: en
+                  count: 1
+                  duration_hrs: 0.1
         "401":
           description: Unauthorized
           schema:
@@ -480,6 +526,8 @@ paths:
           description: Forbidden
           schema:
             $ref: "#/definitions/ErrorResponse"
+        "429":
+          description: Rate Limited
         "500":
           description: Internal Server Error
           schema:
@@ -640,19 +688,18 @@ definitions:
       domain:
         type: string
         description: >-
-          Request a specialized model based on 'language' but optimized for a particular field, e.g. "finance" or "medical".
+          Request a specialized model based on 'language' but optimized for a particular field, e.g. 'finance' or 'medical'.
       output_locale:
         type: string
         description: >-
           Language locale to be used when generating the transcription output, normally specified as an ISO language code
+      model:
+        $ref: "#/definitions/Model"
       operating_point:
         $ref: "#/definitions/OperatingPoint"
+        deprecated: true
         description: |-
-          Specify an operating point to use.
-          Operating points change the transcription process in a high level way, such as altering the acoustic model.
-          The default is `standard`.
-            - `standard`:
-            - `enhanced`: transcription will take longer but be more accurate than 'standard'
+          **Deprecated**: Use `model` instead. `operating_point` is left only for backward compatibility for `standard` and `enhanced`.
       additional_vocab:
         type: array
         x-omitempty: true
@@ -681,10 +728,6 @@ definitions:
             description: |-
               Ranges between zero and one. Higher values will produce more punctuation. The default is 0.5.
           permitted_marks:
-            # Do not add `x-omitempty` here as this breaks behaviour when this array is empty.
-            # An empty `[]` permitted_marks array is valid, to make sure that transcript contains no punctuation marks.
-            # Currently BJA produces a `null` value for this array. UniASR has an exception for this.
-            # See REQ-17613
             type: array
             items:
               type: string
@@ -742,7 +785,7 @@ definitions:
           remove_disfluencies:
             type: boolean
             description: >-
-              If true, words identified as disfluencies (e.g., 'um', 'uh') will be removed from the transcript. If false (default), they are tagged in the transcript as 'disfluency'.
+              If true, words that are identified as disfluencies will be removed from the transcript. If false (default), they are tagged in the transcript as 'disfluency'.
           replacements:
             type: array
             x-omitempty: true
@@ -758,7 +801,7 @@ definitions:
                 to:
                   type: string
             description: >-
-              An array of objects defining custom replacements. Each replacement contains a pair of strings: the text to find ("from:") and the text to replace it with ("to:").
+              An array of objects defining custom replacements. Each replacement contains a pair of strings: the text to find `from` and the text to replace it with `to`.
       speaker_diarization_config:
         description: Configuration for speaker diarization
         type: object
@@ -766,7 +809,7 @@ definitions:
           prefer_current_speaker:
             type: boolean
             description: >-
-              If true, the algorithm will prefer to stay with the current active speaker if it is a close enough match, even if other speakers may be closer.  This is useful for cases where we can flip incorrectly between similar speakers during a single speaker section."
+              If true, the algorithm will prefer to stay with the current active speaker if it is a close enough match, even if other speakers may be closer.  This is useful for cases where we can flip incorrectly between similar speakers during a single speaker section.
           speaker_sensitivity:
             type: number
             format: float
@@ -782,11 +825,7 @@ definitions:
             type: array
             x-omitempty: true
             description: >-
-              Use this option to provide speaker labels linked to their speaker identifiers.
-              When passed, the transcription system will tag spoken words in the transcript
-              with the provided speaker labels whenever any of the specified speakers
-              is detected in the audio. A maximum of 50 speakers identifiers across all speakers
-              can be provided.
+              Use this option to provide speaker labels linked to their speaker identifiers. When passed, the transcription system will tag spoken words in the transcript with the provided speaker labels whenever any of the specified speakers is detected in the audio. A maximum of 50 speakers identifiers across all speakers can be provided.
             items:
               $ref: "#/definitions/SpeakersInputItem"
     example:
@@ -975,6 +1014,8 @@ definitions:
         $ref: "#/definitions/TopicDetectionConfig"
       auto_chapters_config:
         $ref: "#/definitions/AutoChaptersConfig"
+      audio_events_config:
+        $ref: "#/definitions/AudioEventsConfig"
   TranslationConfig:
     required:
       - target_languages
@@ -1014,7 +1055,6 @@ definitions:
           - auto
           - informative
           - conversational
-        default: auto
         description: |
           Choose from three options:
           - `conversational` - Best suited for dialogues involving multiple participants, such as calls, meetings or discussions. It focuses on summarizing key points of the conversation.
@@ -1049,6 +1089,15 @@ definitions:
     type: object
   AutoChaptersConfig:
     type: object
+  AudioEventsConfig:
+    x-omitempty: true
+    type: object
+    properties:
+      types:
+        x-omitempty: true
+        type: array
+        items:
+          type: string
   CreateJobResponse:
     required:
       - id
@@ -1068,11 +1117,6 @@ definitions:
       - data_name
       - id
       - status
-      # config is not required anymore, because we use JobDetails definition for list and get one job endpoints
-      # and in context of the list in BVA where we return all the jobs, returning configs can lead to OOMK due to potentially
-      # large configs, And this is only client side validation so we will enforce config included in the job details
-      # for one job in e2e tests for batch jobs api. I have considered also having two JobDetails definitions with inheritance
-      # but Open API spec 2.0 does not support inheritance.
     type: object
     properties:
       created_at:
@@ -1083,6 +1127,9 @@ definitions:
       data_name:
         type: string
         description: Name of the data file submitted for job.
+      text_name:
+        type: string
+        description: Name of the text file submitted to be aligned to audio.
       duration:
         type: integer
         description: The file duration (in seconds). May be missing for fetch URL jobs.
@@ -1140,6 +1187,25 @@ definitions:
               segment: 8
               seg_start: 963.201
               seg_end: 1091.481
+          transcription_config:
+            language: en
+            additional_vocab:
+              - content: Speechmatics
+                sounds_like:
+                  - speechmatics
+              - content: gnocchi
+                sounds_like:
+                  - nyohki
+                  - nokey
+                  - nochi
+              - content: CEO
+                sounds_like:
+                  - C.E.O.
+              - content: financial crisis
+            diarization: channel
+            channel_diarization_labels:
+              - Agent
+              - Caller
           notification_config:
             - url: https://collector.example.org/callback
               contents: ["transcript", "data"]
@@ -1147,6 +1213,21 @@ definitions:
                 [
                   "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOiJiMDhmODZhZi0zNWRhLTQ4ZjItOGZhYi1jZWYzOTA0NjYwYmQifQ.-xN_h82PHVTCMA9vdoHrcZxH-x5mb11y1537t3rGzcM",
                 ]
+        - created_at: "2018-01-09T11:23:42.984612Z"
+          data_name: hello.wav
+          duration: 130
+          id: 084d1f86-9fe9-11e8-9c91-00155d019c0b
+          status: aligning
+          type: alignment
+          text_name: hello.txt
+          alignment_config:
+            language: en
+          notification_config:
+            - url: https://collector.example.org/trigger-fetch
+              contents: []
+          tracking:
+            title: Project X Intro
+            reference: /data/projects/X/overview/audio/hello.wav
   RetrieveJobResponse:
     required: &ref_0
       - job
@@ -1319,6 +1400,8 @@ definitions:
         items:
           $ref: "#/definitions/AutoChaptersResultError"
         description: List of errors that occurred in the auto chapters stage.
+      alignment_config:
+        $ref: "#/definitions/AlignmentConfig"
       output_config:
         $ref: "#/definitions/OutputConfig"
       language_pack_info:
@@ -1368,7 +1451,6 @@ definitions:
         items:
           type: string
   RecognitionResult:
-    title: RecognitionResult
     description: >-
       An ASR job output item. The primary item types are `word` and `punctuation`. Other item types may be present, for example to provide semantic information of different forms.
     required:
@@ -1442,7 +1524,7 @@ definitions:
               direction: ltr
   WrittenFormRecognitionResult:
     description: >-
-      A WrittenFormRecognitionResult describes a simple object which consists solely of 'word' type entries with a start and end time. It can occur only inside the written_form property of a full RecognitionResult"
+      A WrittenFormRecognitionResult describes a simple object which consists solely of 'word' type entries with a start and end time. It can occur only inside the written_form property of a full RecognitionResult'
     properties:
       alternatives:
         items:
@@ -1467,7 +1549,7 @@ definitions:
     type: "object"
   SpokenFormRecognitionResult:
     description: >-
-      A SpokenFormRecognitionResult describes a simple object which consists solely of 'word' or 'punctuation' type entries with a start and end time. It can occur only inside the spoken_form property of a full "RecognitionResult"
+      A SpokenFormRecognitionResult describes a simple object which consists solely of 'word' or 'punctuation' type entries with a start and end time. It can occur only inside the spoken_form property of a full 'RecognitionResult'
     properties:
       alternatives:
         items:
@@ -1544,6 +1626,26 @@ definitions:
         $ref: "#/definitions/TopicDetectionResult"
       chapters:
         $ref: "#/definitions/AutoChaptersResult"
+      audio_events:
+        x-omitempty: true
+        type: array
+        description: Timestamped audio events, only set if `audio_events_config` is in the config
+        items:
+          $ref: "#/definitions/AudioEventItem"
+      audio_event_summary:
+        type: object
+        description: Summary statistics per event type, keyed by `type`, e.g. music
+        properties:
+          overall:
+            type: object
+            description: Overall summary on all channels
+            $ref: "#/definitions/AudioEventSummary"
+          channels:
+            description: Summary keyed by channel, only set if channel diarization is enabled
+            type: object
+            additionalProperties:
+              type: object
+              $ref: "#/definitions/AudioEventSummary"
   SummarizationResult:
     description: >-
       Summary of the transcript, configured using `summarization_config`.
@@ -1626,12 +1728,11 @@ definitions:
         type: string
         description: The channel label for the segment, if channel diarization is enabled
       confidence:
-        {
-          type: number,
-          format: float,
-          description: A confidence score in the range of 0-1,
+        type: number,
+        format: float,
+        description: |
+          A confidence score in the range of 0-1,
           indicating the model's certainty in the predicted sentiment,
-        }
   SentimentSummary:
     type: object
     description: Holds overall sentiment information, as well as detailed per-speaker and per-channel sentiment data.
@@ -1653,25 +1754,36 @@ definitions:
     type: object
     description: Holds the count of sentiment information grouped by positive, neutral and negative.
     properties:
-      positive_count: { type: integer }
-      negative_count: { type: integer }
-      neutral_count: { type: integer }
+      positive_count:
+        type: integer
+      negative_count:
+        type: integer
+      neutral_count:
+        type: integer
   SentimentSpeakerSummary:
     type: object
     description: Holds sentiment information for a specific speaker.
     properties:
-      speaker: { type: string }
-      positive_count: { type: integer }
-      negative_count: { type: integer }
-      neutral_count: { type: integer }
+      speaker:
+        type: string
+      positive_count:
+        type: integer
+      negative_count:
+        type: integer
+      neutral_count:
+        type: integer
   SentimentChannelSummary:
     type: object
     description: Holds sentiment information for a specific channel.
     properties:
-      channel: { type: string }
-      positive_count: { type: integer }
-      negative_count: { type: integer }
-      neutral_count: { type: integer }
+      channel:
+        type: string
+      positive_count:
+        type: integer
+      negative_count:
+        type: integer
+      neutral_count:
+        type: integer
   TopicDetectionResult:
     description: Main object that holds topic detection results.
     type: object
@@ -1707,9 +1819,14 @@ definitions:
     type: object
     description: Represents a segment of text and its associated topic information.
     properties:
-      text: { type: string }
-      start_time: { type: number, format: float }
-      end_time: { type: number, format: float }
+      text:
+        type: string
+      start_time:
+        type: number
+        format: float
+      end_time:
+        type: number
+        format: float
       topics:
         type: array
         items:
@@ -1718,7 +1835,8 @@ definitions:
     type: object
     description: Represents a topic and its associated information.
     properties:
-      topic: { type: string }
+      topic:
+        type: string
   TopicDetectionSummary:
     type: object
     description: Holds overall information on the topics detected.
@@ -1759,7 +1877,43 @@ definitions:
         description: The start time of the chapter in the audio file
       end_time:
         type: number
-        description: The end time of the chapter in the audio file
+  AudioEventItem:
+    type: object
+    properties:
+      type:
+        type: string
+        description: Kind of audio event. E.g. music
+      start_time:
+        type: number
+        description: Time (in seconds) at which the audio event starts
+        format: float
+      end_time:
+        type: number
+        description: Time (in seconds) at which the audio event ends
+        format: float
+      confidence:
+        type: number
+        format: float
+        description: Prediction confidence associated with this event
+      channel:
+        type: string
+        description: Input channel this event occurred on
+  AudioEventSummary:
+    type: object
+    additionalProperties:
+      type: object
+      $ref: "#/definitions/AudioEventSummaryItem"
+  AudioEventSummaryItem:
+    type: object
+    description: Summary statistics for this audio event type
+    properties:
+      total_duration:
+        type: number
+        description: Total duration (in seconds) of all audio events of this type
+        format: float
+      count:
+        type: number
+        description: Number of events of this type
   TranslationSentence:
     type: object
     properties:
@@ -1840,6 +1994,13 @@ definitions:
         example: "Audio fetch error, http status 418"
   OperatingPoint:
     type: string
+    enum:
+      - standard
+      - enhanced
+  Model:
+    type: string
+    description: >-
+      Specific model to use in transcription (previously called operating point).
     enum:
       - standard
       - enhanced

--- a/spec/batch.yaml
+++ b/spec/batch.yaml
@@ -17,7 +17,7 @@ securityDefinitions:
     type: apiKey
     in: header
     name: Authorization
-    description: "Bearer token authentication. Use the format: Bearer <api_key/jwt>"
+    description: "Bearer token authentication. Use the format: Bearer $API_KEY_OR_JWT"
 security:
   - bearerAuth: []
 paths:

--- a/spec/batch.yaml
+++ b/spec/batch.yaml
@@ -7,34 +7,12 @@ info:
   contact:
     email: support@speechmatics.com
 basePath: /v2
-schemes:
-  - https
 produces:
   - application/json
   # users are using this header for Accept get job and delete job REQ-17778
   - application/vnd.speechmatics.v2+json
-# security:
-# Authentication is handled by a proxy component in front of this API.
-# The authentication proxy must attach the verified userid to all
-# API end points under this path using this custom header.
-parameters:
-  AuthHeader:
-    name: Authorization
-    in: header
-    description: Customer API token
-    required: true
-    type: string
-  EARTag:
-    name: X-SM-EAR-Tag
-    in: header
-    description: Early Access Release Tag
-    required: false
-    type: string
 paths:
   "/jobs":
-    parameters:
-      - $ref: "#/parameters/AuthHeader"
-      - $ref: "#/parameters/EARTag"
     post:
       summary: Create a new job
       consumes:
@@ -50,12 +28,6 @@ paths:
           in: formData
           description: >-
             The data file to be processed. Alternatively the data file can be fetched from a url specified in `JobConfig`.
-          required: false
-          type: file
-        - name: text_file
-          in: formData
-          description: >-
-            For alignment jobs, the text file that the data file should be aligned to.
           required: false
           type: file
         - name: X-SM-Processing-Data
@@ -100,16 +72,14 @@ paths:
             application/json:
               code: 403
               error: Invalid or missing license
-        "410":
-          description: Gone
+        "429":
+          description: Rate Limited
           schema:
             $ref: "#/definitions/ErrorResponse"
           examples:
             application/json:
-              code: 410
-              error: Requested Early Access Release not available
-        "429":
-          description: Rate Limited
+              code: 429
+              error: Max concurrent running jobs exceeded
         "500":
           description: Internal Server Error
           schema:
@@ -134,7 +104,7 @@ paths:
           maximum: 100
           minimum: 1
           description: >-
-            Limit for paginating the request response. Defaults to 100.
+            Limit on the number of items returned. By default, no limit is applied.
           required: false
         - name: include_deleted
           in: query
@@ -163,8 +133,6 @@ paths:
             application/json:
               code: 422
               error: limit in query must be of type int64
-        "429":
-          description: Rate Limited
         "500":
           description: Internal Server Error
           schema:
@@ -174,9 +142,6 @@ paths:
               code: 500
               error: Internal Server Error
   "/jobs/{jobid}":
-    parameters:
-      - $ref: "#/parameters/AuthHeader"
-      - $ref: "#/parameters/EARTag"
     get:
       summary: Get job details
       description: Get job details, including progress and any error reports.
@@ -216,8 +181,6 @@ paths:
             application/json:
               code: 410
               error: Job Expired
-        "429":
-          description: Rate Limited
         "500":
           description: Internal Server Error
           schema:
@@ -279,120 +242,6 @@ paths:
             application/json:
               code: 423
               error: Resource Locked
-        "429":
-          description: Rate Limited
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
-            application/json:
-              code: 500
-              error: Internal Server Error
-  "/jobs/{jobid}/data":
-    parameters:
-      - $ref: "#/parameters/AuthHeader"
-      - $ref: "#/parameters/EARTag"
-    get:
-      summary: Get the data file used as input to a job.
-      produces:
-        - application/octet-stream
-        - application/json
-      parameters:
-        - name: jobid
-          in: path
-          description: ID of the job.
-          required: true
-          type: string
-          x-example: a1b2c3d4e5
-      responses:
-        "200":
-          description: OK
-          schema:
-            type: file
-        "401":
-          description: Unauthorized
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
-            application/json:
-              code: 401
-              error: Permission Denied
-        "404":
-          description: Not found
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
-            application/json:
-              code: 404
-              error: Job not found
-        "410":
-          description: Gone
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
-            application/json:
-              code: 410
-              error: File Expired
-              detail: File deleted from the storage
-        "429":
-          description: Rate Limited
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
-            application/json:
-              code: 500
-              error: Internal Server Error
-  "/jobs/{jobid}/text":
-    parameters:
-      - $ref: "#/parameters/AuthHeader"
-      - $ref: "#/parameters/EARTag"
-    get:
-      summary: Get the text file used as input to an alignment job.
-      produces:
-        - text/plain
-        - application/json
-      parameters:
-        - name: jobid
-          in: path
-          description: ID of the job.
-          required: true
-          type: string
-          x-example: a1b2c3d4e5
-      responses:
-        "200":
-          description: OK
-          schema:
-            type: file
-        "401":
-          description: Unauthorized
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
-            application/json:
-              code: 401
-              error: Permission Denied
-        "404":
-          description: Not found
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
-            application/json:
-              code: 404
-              error: Job not found
-        "410":
-          description: Gone
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
-            application/json:
-              code: 410
-              error: File Expired
-              detail: File deleted from the storage
-        "429":
-          description: Rate Limited
         "500":
           description: Internal Server Error
           schema:
@@ -402,9 +251,6 @@ paths:
               code: 500
               error: Internal Server Error
   "/jobs/{jobid}/transcript":
-    parameters:
-      - $ref: "#/parameters/AuthHeader"
-      - $ref: "#/parameters/EARTag"
     get:
       summary: Get the transcript for a transcription job
       produces:
@@ -532,8 +378,6 @@ paths:
               code: 410
               error: File Expired
               detail: File deleted from the storage
-        "429":
-          description: Rate Limited
         "500":
           description: Internal Server Error
           schema:
@@ -542,83 +386,7 @@ paths:
             application/json:
               code: 500
               error: Internal Server Error
-  "/jobs/{jobid}/alignment":
-    parameters:
-      - $ref: "#/parameters/AuthHeader"
-      - $ref: "#/parameters/EARTag"
-    get:
-      summary: Get the aligned text file for an alignment job.
-      produces:
-        - text/plain
-        - application/json
-      parameters:
-        - name: jobid
-          in: path
-          description: ID of the job.
-          required: true
-          type: string
-          x-example: a1b2c3d4e5
-        - name: tags
-          in: query
-          description: >-
-            Control how timing information is added to the text file provided as input to the alignment job. If set to `word_start_and_end`, SGML tags are inserted at the start and end of each word, for example <time=0.41>. If set to `one_per_line` square bracket tags are inserted at the start of each line, for example `[00:00:00.4] `. The default is `word_start_and_end`.
-          required: false
-          type: string
-          enum:
-            - word_start_and_end
-            - one_per_line
-      responses:
-        "200":
-          description: OK
-          schema:
-            type: file
-          examples:
-            word_start_and_end: |
-              <time=0.41>hello<time=0.76> <time=0.89>world<time=1.18>
-            one_per_line: |
-              [00:00:00.4]    hello world
-        "401":
-          description: Unauthorized
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
-            application/json:
-              code: 401
-              error: Permission Denied
-        "404":
-          description: Not found
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
-            application/json:
-              code: 404
-              error: Job not found
-        "410":
-          description: Gone
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
-            application/json:
-              code: 410
-              error: File Expired
-              detail: File deleted from the storage
-        "429":
-          description: Rate Limited
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
-            application/json:
-              code: 500
-              error: Internal Server Error
-      externalDocs:
-        description: More details of our alignment service can be found here.
-        url: "https://docs.speechmatics.com/speech-to-text/batch/word-alignment"
   "/jobs/{jobid}/log":
-    parameters:
-      - $ref: "#/parameters/AuthHeader"
-      - $ref: "#/parameters/EARTag"
     get:
       summary: Get the log file for a job.
       produces:
@@ -665,8 +433,6 @@ paths:
               code: 410
               error: File Expired
               detail: File deleted from the storage
-        "429":
-          description: Rate Limited
         "500":
           description: Internal Server Error
           schema:
@@ -683,82 +449,7 @@ paths:
             application/json:
               code: 501
               error: Not Implemented
-  "/jobs/{jobid}/object-urls":
-    parameters:
-      - $ref: "#/parameters/AuthHeader"
-      - $ref: "#/parameters/EARTag"
-    get:
-      summary: Get object URLs
-      description: Get signed urls for data files associated to the job.
-      produces:
-        - application/octet-stream
-        - application/json
-      parameters:
-        - name: jobid
-          in: path
-          description: ID of the job.
-          required: true
-          type: string
-          x-example: a1b2c3d4e5
-        - name: ttl
-          in: query
-          required: true
-          type: integer
-          description: "Time to live in seconds for the signed URLs"
-        - name: url_for
-          in: query
-          required: true
-          type: array
-          items:
-            type: string
-            enum:
-              - data
-              - audio_mp3
-              - transcript
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: "#/definitions/RetrieveObjectUrlsResponse"
-        "401":
-          description: Unauthorized
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
-            application/json:
-              code: 401
-              error: Permission Denied
-        "404":
-          description: Not found
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
-            application/json:
-              code: 404
-              error: Job not found
-        "410":
-          description: Gone
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
-            application/json:
-              code: 410
-              error: File Expired
-              detail: File deleted from the storage
-        "429":
-          description: Rate Limited
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
-            application/json:
-              code: 500
-              error: Internal Server Error
   "/usage":
-    parameters:
-      - $ref: "#/parameters/AuthHeader"
-      - $ref: "#/parameters/EARTag"
     get:
       summary: Get usage statistics
       produces:
@@ -781,37 +472,6 @@ paths:
           description: OK
           schema:
             $ref: "#/definitions/UsageResponse"
-          examples:
-            application/json:
-              since: "2021-09-12T00:00:00Z"
-              until: "2022-01-01T23:59:59Z"
-              summary:
-                - mode: batch
-                  type: transcription
-                  count: 5
-                  duration_hrs: 1.53
-                - mode: batch
-                  type: alignment
-                  count: 1
-                  duration_hrs: 0.1
-              details:
-                - mode: batch
-                  type: transcription
-                  language: sv
-                  operating_point: standard
-                  count: 4
-                  duration_hrs: 1.33
-                - mode: batch
-                  type: transcription
-                  language: de
-                  operating_point: enhanced
-                  count: 1
-                  duration_hrs: 0.2
-                - mode: batch
-                  type: alignment
-                  language: en
-                  count: 1
-                  duration_hrs: 0.1
         "401":
           description: Unauthorized
           schema:
@@ -820,8 +480,6 @@ paths:
           description: Forbidden
           schema:
             $ref: "#/definitions/ErrorResponse"
-        "429":
-          description: Rate Limited
         "500":
           description: Internal Server Error
           schema:
@@ -850,7 +508,6 @@ definitions:
           - Job error
           - Job Expired
           - Job In Progress
-          - Job is not of type alignment
           - Job is not of type transcription
           - Job not found
           - Job rejected
@@ -859,19 +516,19 @@ definitions:
           - Malformed request
           - Missing callback
           - Missing data_file
-          - Missing text_file
           - No language selected
           - Not Implemented
           - Permission Denied
           - Requested product not available
           - Transcription not ready
           - Log file not available
-          - Requested Early Access Release not available
           - Unprocessable Entity
+          - Max concurrent running jobs exceeded
       detail:
         type: string
         description: The details of the error.
   TrackingData:
+    type: object
     properties:
       title:
         type: string
@@ -899,6 +556,7 @@ definitions:
   DataFetchConfig:
     required:
       - url
+    type: object
     properties:
       url:
         type: string
@@ -909,15 +567,8 @@ definitions:
           type: string
         description: >-
           A list of additional headers to be added to the input fetch request when using http or https. This is intended to support authentication or authorization, for example by supplying an OAuth2 bearer token.
-  AlignmentConfig:
-    required:
-      - language
-    properties:
-      language:
-        type: string
-    example:
-      language: en
   TranslationError:
+    type: object
     properties:
       type:
         type: string
@@ -929,6 +580,7 @@ definitions:
         description: >-
           Human readable error message
   SummarizationError:
+    type: object
     properties:
       type:
         type: string
@@ -940,6 +592,7 @@ definitions:
         description: >-
           Human readable error message
   SentimentAnalysisError:
+    type: object
     properties:
       type:
         type: string
@@ -951,6 +604,7 @@ definitions:
         description: >-
           Human readable error message
   TopicDetectionError:
+    type: object
     properties:
       type:
         type: string
@@ -963,6 +617,7 @@ definitions:
         description: >-
           Human readable error message
   AutoChaptersResultError:
+    type: object
     properties:
       type:
         type: string
@@ -1016,6 +671,7 @@ definitions:
         description: >-
           List of custom words or phrases that should be recognized. Alternative pronunciations can be specified to aid recognition.
       punctuation_overrides:
+        type: object
         properties:
           sensitivity:
             type: number
@@ -1080,8 +736,8 @@ definitions:
             description: >-
               Controls the lower limit of audio volume at which speech and audio events will be transcribed. If the volume limit is very low, then most sound will be passed to the speech recognition engine. Higher numbers will cut out increasing amounts of sound.
       transcript_filtering_config:
+        description: Configuration for applying filtering to the transcription
         type: object
-        description: Configuration for applying filtering to the transcription.
         properties:
           remove_disfluencies:
             type: boolean
@@ -1099,16 +755,13 @@ definitions:
               properties:
                 from:
                   type: string
-                  description: >-
-                    The text or pattern identified to be replaced.
                 to:
                   type: string
-                  description: >-
-                    The corrected or formatted string to appear in the transcript.
             description: >-
               An array of objects defining custom replacements. Each replacement contains a pair of strings: the text to find ("from:") and the text to replace it with ("to:").
       speaker_diarization_config:
         description: Configuration for speaker diarization
+        type: object
         properties:
           prefer_current_speaker:
             type: boolean
@@ -1135,7 +788,7 @@ definitions:
               is detected in the audio. A maximum of 50 speakers identifiers across all speakers
               can be provided.
             items:
-              $ref: '#/definitions/SpeakersInputItem'
+              $ref: "#/definitions/SpeakersInputItem"
     example:
       language: en
       output_locale: en-GB
@@ -1157,10 +810,9 @@ definitions:
         - Caller
         - Agent
   NotificationConfig:
-    type: object
-    title: NotificationConfig
     required:
       - url
+    type: object
     properties:
       url:
         type: string
@@ -1202,9 +854,6 @@ definitions:
             - transcript.json-v2
             - transcript.txt
             - transcript.srt
-            - alignment
-            - alignment.word_start_and_end
-            - alignment.one_per_line
             - data
             - text
         description: >-
@@ -1235,6 +884,7 @@ definitions:
       Properties of the language pack.
     required:
       - word_delimiter
+    type: object
     properties:
       language_description:
         type: string
@@ -1275,7 +925,6 @@ definitions:
   JobType:
     type: string
     enum:
-      - alignment
       - transcription
   JobConfig:
     description: |
@@ -1295,6 +944,7 @@ definitions:
       possible in the job results and in callbacks.
     required:
       - type
+    type: object
     properties:
       type:
         $ref: "#/definitions/JobType"
@@ -1302,8 +952,6 @@ definitions:
         $ref: "#/definitions/DataFetchConfig"
       fetch_text:
         $ref: "#/definitions/DataFetchConfig"
-      alignment_config:
-        $ref: "#/definitions/AlignmentConfig"
       transcription_config:
         $ref: "#/definitions/TranscriptionConfig"
       notification_config:
@@ -1327,11 +975,10 @@ definitions:
         $ref: "#/definitions/TopicDetectionConfig"
       auto_chapters_config:
         $ref: "#/definitions/AutoChaptersConfig"
-      audio_events_config:
-        $ref: "#/definitions/AudioEventsConfig"
   TranslationConfig:
     required:
       - target_languages
+    type: object
     properties:
       target_languages:
         type: array
@@ -1339,6 +986,7 @@ definitions:
         items:
           type: string
   LanguageIdentificationConfig:
+    type: object
     properties:
       expected_languages:
         type: array
@@ -1390,6 +1038,7 @@ definitions:
           - paragraphs
           - bullets
   TopicDetectionConfig:
+    type: object
     properties:
       topics:
         x-omitempty: true
@@ -1400,18 +1049,10 @@ definitions:
     type: object
   AutoChaptersConfig:
     type: object
-  AudioEventsConfig:
-    x-omitempty: true
-    type: object
-    properties:
-      types:
-        x-omitempty: true
-        type: array
-        items:
-          type: string
   CreateJobResponse:
     required:
       - id
+    type: object
     properties:
       id:
         type: string
@@ -1432,6 +1073,7 @@ definitions:
       # large configs, And this is only client side validation so we will enforce config included in the job details
       # for one job in e2e tests for batch jobs api. I have considered also having two JobDetails definitions with inheritance
       # but Open API spec 2.0 does not support inheritance.
+    type: object
     properties:
       created_at:
         type: string
@@ -1441,9 +1083,6 @@ definitions:
       data_name:
         type: string
         description: Name of the data file submitted for job.
-      text_name:
-        type: string
-        description: Name of the text file submitted to be aligned to audio.
       duration:
         type: integer
         description: The file duration (in seconds). May be missing for fetch URL jobs.
@@ -1478,6 +1117,7 @@ definitions:
   RetrieveJobsResponse:
     required:
       - jobs
+    type: object
     properties:
       jobs:
         type: array
@@ -1500,25 +1140,6 @@ definitions:
               segment: 8
               seg_start: 963.201
               seg_end: 1091.481
-          transcription_config:
-            language: en
-            additional_vocab:
-              - content: Speechmatics
-                sounds_like:
-                  - speechmatics
-              - content: gnocchi
-                sounds_like:
-                  - nyohki
-                  - nokey
-                  - nochi
-              - content: CEO
-                sounds_like:
-                  - C.E.O.
-              - content: financial crisis
-            diarization: channel
-            channel_diarization_labels:
-              - Agent
-              - Caller
           notification_config:
             - url: https://collector.example.org/callback
               contents: ["transcript", "data"]
@@ -1526,24 +1147,10 @@ definitions:
                 [
                   "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOiJiMDhmODZhZi0zNWRhLTQ4ZjItOGZhYi1jZWYzOTA0NjYwYmQifQ.-xN_h82PHVTCMA9vdoHrcZxH-x5mb11y1537t3rGzcM",
                 ]
-        - created_at: "2018-01-09T11:23:42.984612Z"
-          data_name: hello.wav
-          duration: 130
-          id: 084d1f86-9fe9-11e8-9c91-00155d019c0b
-          status: aligning
-          type: alignment
-          text_name: hello.txt
-          alignment_config:
-            language: en
-          notification_config:
-            - url: https://collector.example.org/trigger-fetch
-              contents: []
-          tracking:
-            title: Project X Intro
-            reference: /data/projects/X/overview/audio/hello.wav
   RetrieveJobResponse:
     required: &ref_0
       - job
+    type: object
     properties: &ref_1
       job:
         $ref: "#/definitions/JobDetails"
@@ -1592,6 +1199,7 @@ definitions:
             seg_end: 1091.481
   DeleteJobResponse:
     required: *ref_0
+    type: object
     properties: *ref_1
     example:
       job:
@@ -1644,6 +1252,7 @@ definitions:
       - data_name
       - duration
       - id
+    type: object
     properties:
       created_at:
         type: string
@@ -1661,9 +1270,6 @@ definitions:
         type: string
         example: a1b2c3d4e5
         description: The unique id assigned to the job.
-      text_name:
-        type: string
-        description: Name of the text file submitted to be aligned to audio.
       tracking:
         $ref: "#/definitions/TrackingData"
   RecognitionMetadata:
@@ -1672,6 +1278,7 @@ definitions:
     required:
       - created_at
       - type
+    type: object
     properties:
       created_at:
         type: string
@@ -1682,10 +1289,6 @@ definitions:
         $ref: "#/definitions/JobType"
       transcription_config:
         $ref: "#/definitions/TranscriptionConfig"
-      orchestrator_version:
-        type: string
-        example: "2025.11.07+cd4ff775c0+14.7.0"
-        description: The engine version used to generate transcription output.
       translation_errors:
         x-omitempty: true
         type: array
@@ -1716,8 +1319,6 @@ definitions:
         items:
           $ref: "#/definitions/AutoChaptersResultError"
         description: List of errors that occurred in the auto chapters stage.
-      alignment_config:
-        $ref: "#/definitions/AlignmentConfig"
       output_config:
         $ref: "#/definitions/OutputConfig"
       language_pack_info:
@@ -1725,10 +1326,15 @@ definitions:
       language_identification:
         $ref: "#/definitions/LanguageIdentificationResult"
         description: >-
-          Result of the language identification of the audio, configured using `language_identification_config`,  or setting the transcription language to `auto`.
+          Result of the language identification of the audio, configured using `language_identification_config`, or setting the transcription language to `auto`.
+      orchestrator_version:
+        type: string
+        description: >-
+          Orchestrator version in PEP 440 Format or set to 'version_not_found' as default.
   RecognitionDisplay:
     required:
       - direction
+    type: object
     properties:
       direction:
         type: string
@@ -1742,6 +1348,7 @@ definitions:
       - content
       - confidence
       - language
+    type: object
     properties:
       content:
         type: string
@@ -1768,6 +1375,7 @@ definitions:
       - start_time
       - end_time
       - type
+    type: object
     properties:
       channel:
         type: string
@@ -1884,7 +1492,6 @@ definitions:
       - alternatives
     type: "object"
   RetrieveTranscriptResponse:
-    title: RetrieveTranscriptResponse
     type: object
     required:
       - format
@@ -1908,7 +1515,7 @@ definitions:
         type: array
         x-omitempty: true
         items:
-          $ref: '#/definitions/SpeakersResultItem'
+          $ref: "#/definitions/SpeakersResultItem"
         description: List of unique speaker identifiers detected in the transcript.
       translations:
         type: object
@@ -1937,26 +1544,6 @@ definitions:
         $ref: "#/definitions/TopicDetectionResult"
       chapters:
         $ref: "#/definitions/AutoChaptersResult"
-      audio_events:
-        x-omitempty: true
-        type: array
-        description: Timestamped audio events, only set if `audio_events_config` is in the config
-        items:
-          $ref: "#/definitions/AudioEventItem"
-      audio_event_summary:
-        type: object
-        description: Summary statistics per event type, keyed by `type`, e.g. music
-        properties:
-          overall:
-            type: object
-            description: Overall summary on all channels
-            $ref: "#/definitions/AudioEventSummary"
-          channels:
-            description: Summary keyed by channel, only set if channel diarization is enabled
-            type: object
-            additionalProperties:
-              type: object
-              $ref: "#/definitions/AudioEventSummary"
   SummarizationResult:
     description: >-
       Summary of the transcript, configured using `summarization_config`.
@@ -2050,7 +1637,7 @@ definitions:
     description: Holds overall sentiment information, as well as detailed per-speaker and per-channel sentiment data.
     properties:
       overall:
-        description: Summary for all segments in the file
+        description: Summary of overall sentiment data.
         $ref: "#/definitions/SentimentSummaryDetail"
       speakers:
         type: array
@@ -2173,43 +1760,6 @@ definitions:
       end_time:
         type: number
         description: The end time of the chapter in the audio file
-  AudioEventItem:
-    type: object
-    properties:
-      type:
-        type: string
-        description: Kind of audio event. E.g. music
-      start_time:
-        type: number
-        description: Time (in seconds) at which the audio event starts
-        format: float
-      end_time:
-        type: number
-        description: Time (in seconds) at which the audio event ends
-        format: float
-      confidence:
-        type: number
-        format: float
-        description: Prediction confidence associated with this event
-      channel:
-        type: string
-        description: Input channel this event occurred on
-  AudioEventSummary:
-    type: object
-    additionalProperties:
-      type: object
-      $ref: "#/definitions/AudioEventSummaryItem"
-  AudioEventSummaryItem:
-    type: object
-    description: Summary statistics for this audio event type
-    properties:
-      total_duration:
-        type: number
-        description: Total duration (in seconds) of all audio events of this type
-        format: float
-      count:
-        type: number
-        description: Number of events of this type
   TranslationSentence:
     type: object
     properties:
@@ -2345,15 +1895,6 @@ definitions:
         type: number
         format: float
         description: Total duration of billable jobs (in hours) this cycle
-  RetrieveObjectUrlsResponse:
-    type: object
-    properties:
-      data:
-        type: string
-      audio_mp3:
-        type: string
-      transcript:
-        type: string
   SpeakersInputItem:
     type: object
     properties:

--- a/spec/code-samples/batch-api/jobs/post.js
+++ b/spec/code-samples/batch-api/jobs/post.js
@@ -12,7 +12,7 @@ const response = await client.createTranscriptionJob({
   config: {
     type: "transcription",
     transcription_config: {
-      operating_point: "enhanced",
+      model: "enhanced",
       language: "en",
     },
   },

--- a/spec/code-samples/batch-api/jobs/post.sh
+++ b/spec/code-samples/batch-api/jobs/post.sh
@@ -4,4 +4,4 @@ PATH_TO_FILE="example.wav"
 curl -L -X POST "https://eu1.asr.api.speechmatics.com/v2/jobs/" \
 -H "Authorization: Bearer ${API_KEY}" \
 -F data_file=@${PATH_TO_FILE} \
--F config='{"type": "transcription","transcription_config": { "operating_point":"enhanced", "language": "en" }}'
+-F config='{"type": "transcription","transcription_config": { "model":"enhanced", "language": "en" }}'

--- a/spec/realtime.yaml
+++ b/spec/realtime.yaml
@@ -811,7 +811,7 @@ components:
     OperatingPoint:
       type: string
       description: |
-        Which model you wish to use. See [Operating points](http://docs.speechmatics.com/speech-to-text/#operating-points) for more details.
+        Which model you wish to use. See [Operating points](http://docs.speechmatics.com/speech-to-text/#models) for more details.
       enum:
         - standard
         - enhanced

--- a/spec/realtime.yaml
+++ b/spec/realtime.yaml
@@ -770,6 +770,8 @@ components:
           default: true
         operating_point:
           $ref: "#/components/schemas/OperatingPoint"
+        model:
+          $ref: "#/components/schemas/Model"
         punctuation_overrides:
           $ref: "#/components/schemas/PunctuationOverrides"
         conversation_config:
@@ -809,6 +811,14 @@ components:
         conversation_config:
           $ref: "#/components/schemas/ConversationConfig"
     OperatingPoint:
+      type: string
+      deprecated: true
+      description: |
+        **Deprecated**: Kept for backward compatibility only. Use `model` instead going forward.
+      enum:
+        - standard
+        - enhanced
+    Model:
       type: string
       description: |
         Which model you wish to use. See [Operating points](http://docs.speechmatics.com/speech-to-text/#models) for more details.

--- a/spec/realtime.yaml
+++ b/spec/realtime.yaml
@@ -330,7 +330,7 @@ components:
           "transcription_config":
             {
               "language": "en",
-              "operating_point": "enhanced",
+              "model": "enhanced",
               "output_locale": "en-US",
               "additional_vocab": ["gnocchi", "bucatini", "bigoli"],
               "diarization": "speaker",


### PR DESCRIPTION
### Summary

This PR updates the batch API spec and docs to reflect the deprecation of operating_point in favour of the new model field.

Batch API spec (spec/batch.yaml)
  - Adds a dedicated model field to TranscriptionConfig with values standard and enhanced (previously called operating points)
  - Marks operating_point as deprecated with a note to use model instead; the field is retained for backward compatibility
  - Adds a dedicated type for the model field and updates its description

Documentation (MDX files)
  - Updates all JSON code examples across speech-to-text, realtime, and integration docs to use "model": "enhanced" instead of "operating_point": "enhanced"
  - Renames the "Operating points" section in the languages reference to "Models" (anchor #operating-points preserved to avoid breaking existing links)
  - Updates prose throughout to use "model" / "enhanced model" / "standard model" rather than "operating point" terminology

### Not in scope for this PR
  - Third-party integration SDK docs (pipecat, livekit) — parameter names are controlled by those libraries
  - Python RT SDK and Voice SDK code examples — SDK not yet updated (will update next)
  - Container/virtual appliance deployment docs — separate config surface