### PR TITLE
Update SaaS STT examples to all specify model where missing

### DIFF
--- a/docs/speech-to-text/app-analytics.mdx
+++ b/docs/speech-to-text/app-analytics.mdx
@@ -23,7 +23,7 @@ PATH_TO_FILE="example.wav"
 curl -L -X POST "https://eu1.asr.api.speechmatics.com/v2/jobs/?sm-app=${APP_ID}" \
     -H "Authorization: Bearer ${API_KEY}" \
     -F data_file=@${PATH_TO_FILE} \
-    -F config='{"type": "transcription","transcription_config": { "language": "en" }}'
+    -F config='{"type": "transcription","transcription_config": { "model": "enhanced","language": "en" }}'
 ```
 
   </TabItem>

--- a/docs/speech-to-text/batch/batch-diarization.mdx
+++ b/docs/speech-to-text/batch/batch-diarization.mdx
@@ -41,6 +41,7 @@ The feature is disabled by default. To enable speaker diarization, `diarization`
 {
   "type": "transcription",
   "transcription_config": {
+    "model": "enhanced",
     "language": "en",
     // highlight-start
     "diarization": "speaker"
@@ -95,6 +96,7 @@ To enable it, set the `diarization` property to `channel`. You can also add cust
 {
   "type": "transcription",
   "transcription_config": {
+    "model": "enhanced",
     "language": "en",
     // highlight-start
     "diarization": "channel",
@@ -137,6 +139,7 @@ You can configure the sensitivity of speaker detection by using the `speaker_sen
 {
   "type": "transcription",
   "transcription_config": {
+    "model": "enhanced",
     "language": "en",
     // highlight-start
     "diarization": "speaker",
@@ -160,6 +163,7 @@ You can reduce the likelihood of incorrectly switching between similar sounding 
 {
   "type": "transcription",
   "transcription_config": {
+    "model": "enhanced",
     "language": "en",
     // highlight-start
     "diarization": "speaker",

--- a/docs/speech-to-text/batch/input.mdx
+++ b/docs/speech-to-text/batch/input.mdx
@@ -51,6 +51,7 @@ If you store your digital media in cloud storage (for example AWS S3 or Azure Bl
 {
   "type": "transcription",
   "transcription_config": {
+    "model": "enhanced",
     "language": "en"
   },
   "fetch_data": {

--- a/docs/speech-to-text/batch/language-identification.mdx
+++ b/docs/speech-to-text/batch/language-identification.mdx
@@ -30,6 +30,7 @@ Once you are set up, just set `language` to `auto` to use Automatic Language Ide
 {
   "type": "transcription",
   "transcription_config": {
+    "model": "enhanced",
     "language": "auto"
   }
 }
@@ -51,6 +52,7 @@ If you expect the audio to be one of a restricted set of languages, you can prov
 {
   "type": "transcription",
   "transcription_config": {
+    "model": "enhanced",
     "language": "auto"
   },
   "language_identification_config": {
@@ -75,6 +77,7 @@ To configure a job which would use the highest confidence identified language:
 {
   "type": "transcription",
   "transcription_config": {
+    "model": "enhanced",
     "language": "auto"
   },
   "language_identification_config": {
@@ -88,6 +91,7 @@ To configure a job which would use your predefined Default Language:
 {
   "type": "transcription",
   "transcription_config": {
+    "model": "enhanced",
     "language": "auto"
   },
   "language_identification_config": {
@@ -127,6 +131,7 @@ To configure a job with Default Language:
 {
   "type": "transcription",
   "transcription_config": {
+    "model": "enhanced",
     "language": "auto"
   },
   "language_identification_config": {
@@ -225,6 +230,7 @@ Example bad config:
 {
   "type": "transcription",
   "transcription_config": {
+    "model": "enhanced",
     "language": "en"
   },
   "language_identification_config": {

--- a/docs/speech-to-text/batch/output.mdx
+++ b/docs/speech-to-text/batch/output.mdx
@@ -178,6 +178,7 @@ For example:
 {
   "type": "transcription",
   "transcription_config": {
+    "model": "enhanced",
     "language": "en"
   },
   // highlight-start
@@ -219,5 +220,5 @@ PATH_TO_FILE="example.wav"
 curl -L -X POST "https://eu1.asr.api.speechmatics.com/v2/jobs/?sm-app=${APP_ID}" \
     -H "Authorization: Bearer ${API_KEY}" \
     -F data_file=@${PATH_TO_FILE} \
-    -F config='{"type": "transcription","transcription_config": { "language": "en" }}'
+    -F config='{"type": "transcription","transcription_config": { "model": "enhanced","language": "en" }}'
 ```

--- a/docs/speech-to-text/batch/speaker-identification.mdx
+++ b/docs/speech-to-text/batch/speaker-identification.mdx
@@ -32,6 +32,7 @@ You can request the identifiers back from the engine by setting the `get_speaker
 {
   "type": "transcription",
   "transcription_config": {
+    "model": "enhanced",
     "language": "en",
     "diarization": "speaker"
     "speaker_diarization_config": {
@@ -94,6 +95,7 @@ An example configuration is shown below:
 {
   "type": "transcription",
   "transcription_config": {
+    "model": "enhanced",
     "language": "en",
     "diarization": "speaker",
     "speaker_diarization_config": {

--- a/docs/speech-to-text/batch/speech-intelligence/auto-chapters.mdx
+++ b/docs/speech-to-text/batch/speech-intelligence/auto-chapters.mdx
@@ -39,6 +39,7 @@ If you're new to Speechmatics, please see our guide on [Transcribing a File](/sp
 {
   "type": "transcription",
   "transcription_config": {
+    "model": "enhanced",
     "language": "en"
   },
   // highlight-start

--- a/docs/speech-to-text/batch/speech-intelligence/sentiment-analysis.mdx
+++ b/docs/speech-to-text/batch/speech-intelligence/sentiment-analysis.mdx
@@ -19,6 +19,7 @@ If you're new to Speechmatics, please see our guide on [Transcribing a File](/sp
 {
   "type": "transcription",
   "transcription_config": {
+    "model": "enhanced",
     "language": "en"
   },
   "sentiment_analysis_config": {}

--- a/docs/speech-to-text/batch/speech-intelligence/summarization.mdx
+++ b/docs/speech-to-text/batch/speech-intelligence/summarization.mdx
@@ -49,6 +49,7 @@ If you're new to Speechmatics, please see our guide on [Transcribing a File](/sp
 {
   "type": "transcription",
   "transcription_config": {
+    "model": "enhanced",
     "language": "en"
   },
   "summarization_config": {}  # You can also configure the summary. See below for more detail.

--- a/docs/speech-to-text/batch/speech-intelligence/topic-detection.mdx
+++ b/docs/speech-to-text/batch/speech-intelligence/topic-detection.mdx
@@ -30,6 +30,7 @@ If you're new to Speechmatics, please see our guide on [Transcribing a File](/sp
 {
   "type": "transcription",
   "transcription_config": {
+    "model": "enhanced",
     "language": "en"
   },
   // highlight-start
@@ -105,6 +106,7 @@ If you have a specific list of topics you wish to detect, you can provide this i
 {
   "type": "transcription",
   "transcription_config": {
+    "model": "enhanced",
     "language": "en"
   },
   "topic_detection_config": {

--- a/docs/speech-to-text/features/custom-dictionary.mdx
+++ b/docs/speech-to-text/features/custom-dictionary.mdx
@@ -21,6 +21,7 @@ Prior to using this feature, consider the following:
 
 ```json
 "transcription_config": {
+  "model": "enhanced",
   "language": "en",
   "additional_vocab": [
     {

--- a/docs/speech-to-text/formatting.mdx
+++ b/docs/speech-to-text/formatting.mdx
@@ -24,6 +24,7 @@ Some languages have multiple spelling conventions that vary by region. To ensure
 {
   "type": "transcription",
   "transcription_config": {
+    "model": "enhanced",
     "language": "en",
     "output_locale": "en-GB"
   }
@@ -151,6 +152,7 @@ You can automatically remove disfluencies from your transcript:
 
 ```json
 "transcription_config": {
+  "model": "enhanced",
   "language": "en",
   "transcript_filtering_config": {
     "remove_disfluencies": true
@@ -174,6 +176,7 @@ Word replacement lets you substitute specific words or patterns in the transcrip
 
 ```json
 "transcription_config": {
+  "model": "enhanced",
   "language": "en",
   "transcript_filtering_config": {
     "replacements": [
@@ -230,6 +233,7 @@ To include detailed information about entities in your JSON output, add this to 
 {
   "type": "transcription",
   "transcription_config": {
+    "model": "enhanced",
     "language": "en",
     "enable_entities": true
   }
@@ -384,6 +388,7 @@ You can control which punctuation marks appear in your transcripts using the `pu
 
 ```json
 "transcription_config": {
+   "model": "enhanced",
    "language": "en",
     // highlight-start
    "punctuation_overrides": {

--- a/docs/speech-to-text/realtime/quickstart.mdx
+++ b/docs/speech-to-text/realtime/quickstart.mdx
@@ -99,8 +99,9 @@ To receive partials, add the following changes and handlers to your code:
 
 <Tabs groupId="language">
   <TabItem value="python" label="Python">
-    ```python {4,8-11}
+    ```python {5,9-12}
     config = TranscriptionConfig(
+        model="enhanced",
         language="en",
         max_delay=0.7,
         enable_partials=True,
@@ -119,9 +120,10 @@ To receive partials, add the following changes and handlers to your code:
     ```
   </TabItem>
   <TabItem value="javascript" label="JavaScript">
-    ```javascript {5,12-13}
+    ```javascript {6,13-14}
     await client.start(jwt, {
         transcription_config: {
+            model: "enhanced",
             max_delay: 0.7,
             language: "en",
             enable_partials: true,

--- a/docs/speech-to-text/realtime/speaker-identification.mdx
+++ b/docs/speech-to-text/realtime/speaker-identification.mdx
@@ -54,6 +54,7 @@ Example speaker diarization config:
 {
   "type": "transcription",
   "transcription_config": {
+    "model": "enhanced",
     "language": "en",
     "diarization": "speaker"
     "speaker_diarization_config": {
@@ -89,6 +90,7 @@ An example configuration is shown below:
 {
   "type": "transcription",
   "transcription_config": {
+    "model": "enhanced",
     "language": "en",
     "diarization": "speaker",
     "speaker_diarization_config": {

--- a/docs/speech-to-text/realtime/turn-detection.mdx
+++ b/docs/speech-to-text/realtime/turn-detection.mdx
@@ -49,6 +49,7 @@ To enable end of utterance detection, include the following in the [StartRecogni
 {
   "type": "transcription",
   "transcription_config": {
+    "model": "enhanced",
     // highlight-start
     "conversation_config": {
         "end_of_utterance_silence_trigger": 0.5


### PR DESCRIPTION
- Quickstarts for Batch and Realtime (SaaS) have updated examples adding `model: "enhanced"` where none present
- Voice agents API and on-prem pages left unchanged. Will update as needed