### PR TITLE
Add global.rt.speechmatics.com to Realtime endpoints docs

### DIFF
--- a/docs/api-ref/realtime-transcription-websocket.mdx
+++ b/docs/api-ref/realtime-transcription-websocket.mdx
@@ -23,6 +23,10 @@ import realtimeSchema from "!asyncapi-schema-loader!@site/spec/realtime.yaml";
   <h2 className="openapi__method-endpoint-path">wss://eu.rt.speechmatics.com/v2/</h2>
 </pre>
 
+:::info
+You can also connect to `wss://global.rt.speechmatics.com/v2/`, which automatically routes to the lowest-latency region. Customers with data residency requirements should use a regional endpoint (`eu.rt` / `us.rt`) instead. See [Supported endpoints](/get-started/authentication#supported-endpoints).
+:::
+
 ## Protocol overview
 
 A basic Realtime session will have the following message exchanges:

--- a/docs/api-ref/realtime-transcription-websocket.mdx
+++ b/docs/api-ref/realtime-transcription-websocket.mdx
@@ -24,7 +24,7 @@ import realtimeSchema from "!asyncapi-schema-loader!@site/spec/realtime.yaml";
 </pre>
 
 :::info
-You can also connect to `wss://global.rt.speechmatics.com/v2/`, which automatically routes to the lowest-latency region. Customers with data residency requirements should use a regional endpoint (`eu.rt` / `us.rt`) instead. See [Supported endpoints](/get-started/authentication#supported-endpoints).
+You can also connect to `wss://global.rt.speechmatics.com/v2/`, which automatically routes to the lowest-latency region. See [Supported endpoints](/get-started/authentication#supported-endpoints).
 :::
 
 ## Protocol overview

--- a/docs/api-ref/realtime-transcription-websocket.mdx
+++ b/docs/api-ref/realtime-transcription-websocket.mdx
@@ -24,7 +24,7 @@ import realtimeSchema from "!asyncapi-schema-loader!@site/spec/realtime.yaml";
 </pre>
 
 :::info
-You can also connect to `wss://global.rt.speechmatics.com/v2/`, which automatically routes to the lowest-latency region. See [Supported endpoints](/get-started/authentication#supported-endpoints).
+You can either pin to a specific region for data residency or connect to `wss://global.rt.speechmatics.com/v2/`, which automatically routes each connection to the nearest region for lowest latency. See [Supported endpoints](/get-started/authentication#supported-endpoints).
 :::
 
 ## Protocol overview

--- a/docs/get-started/authentication.mdx
+++ b/docs/get-started/authentication.mdx
@@ -186,7 +186,7 @@ Note that when starting a Realtime transcription session in the browser, you mus
 |--------------|-----------|-----------------------------------------------------------
 | `ttl`        | Yes            | Integer: 60-86400. The temporary key's time to live in seconds. **Note** We suggest using the shortest TTL possible to minimise security risks.
 | `client_ref` | No             | String. When provided, `batch` tokens can only create and retrieve jobs with that reference; without it, they can access any job. **Must** be set when temporary keys are exposed to end-users to prevent accessing another user's data. `client_ref` is ignored when requesting `rt` tokens.
-| `region`     | No             | **Deprecated.** String: `eu` (default), `usa`, or `au` (Batch transcription only). Region is determined by the [endpoint you call](#supported-endpoints), not the key. Still accepted for backward compatibility, but it has no effect.
+| `region`     | No             | **Deprecated.** String: `eu` (default), `usa`, or `au` (Batch transcription only). Region is determined by the [endpoint you call](#supported-endpoints). Still accepted for backward compatibility, but it has no effect.
 
 
 ## Next steps

--- a/docs/get-started/authentication.mdx
+++ b/docs/get-started/authentication.mdx
@@ -186,7 +186,7 @@ Note that when starting a Realtime transcription session in the browser, you mus
 |--------------|-----------|-----------------------------------------------------------
 | `ttl`        | Yes            | Integer: 60-86400. The temporary key's time to live in seconds. **Note** We suggest using the shortest TTL possible to minimise security risks.
 | `client_ref` | No             | String. When provided, `batch` tokens can only create and retrieve jobs with that reference; without it, they can access any job. **Must** be set when temporary keys are exposed to end-users to prevent accessing another user's data. `client_ref` is ignored when requesting `rt` tokens.
-| `region`     | No             | **Deprecated.** String: `eu` (default), `usa`, or `au` (Batch transcription only). Region is determined by the endpoint you call, not the key. Still accepted for backward compatibility, but it has no effect.
+| `region`     | No             | **Deprecated.** String: `eu` (default), `usa`, or `au` (Batch transcription only). Region is determined by the [endpoint you call](#supported-endpoints), not the key. Still accepted for backward compatibility, but it has no effect.
 
 
 ## Next steps

--- a/docs/get-started/authentication.mdx
+++ b/docs/get-started/authentication.mdx
@@ -87,13 +87,13 @@ The EU2 and US2 Batch SaaS endpoints are provided for enterprise customer high a
 
 Speechmatics Realtime SaaS supports the following endpoints for production use:
 
-| Customer type | Region       | Endpoint                       |
-| ------------- | ------------ | ------------------------------ |
-| All           | All regions  | **global.rt.speechmatics.com** |
-| All           | EU1 (Europe) | **eu.rt.speechmatics.com**     |
-| All           | US1 (USA)    | **us.rt.speechmatics.com**     |
+| Region       | Endpoint                       |
+| ------------ | ------------------------------ |
+| All regions  | **global.rt.speechmatics.com** |
+| EU1 (Europe) | **eu.rt.speechmatics.com**     |
+| US1 (USA)    | **us.rt.speechmatics.com**     |
 
-`global.rt.speechmatics.com` automatically routes each connection to the lowest-latency region, so you do not have to choose one. The regional endpoints remain available if you want to pin to a specific region.
+`global.rt.speechmatics.com` automatically routes each connection to the nearest region for lowest latency, so you don't have to select one. The regional endpoints remain available if you want to pin to a specific region.
 
 :::warning
 `global.rt.speechmatics.com` may route a connection to any region. If you have data residency or compliance requirements, use a regional endpoint (`eu.rt.speechmatics.com` or `us.rt.speechmatics.com`) instead.

--- a/docs/get-started/authentication.mdx
+++ b/docs/get-started/authentication.mdx
@@ -87,10 +87,17 @@ The EU2 and US2 Batch SaaS endpoints are provided for enterprise customer high a
 
 Speechmatics Realtime SaaS supports the following endpoints for production use:
 
-| Customer type | Region       | Endpoint               |
-| ------------- | ------------ | ---------------------- |
-| All           | EU1 (Europe) | eu.rt.speechmatics.com |
-| All           | US1 (USA)    | us.rt.speechmatics.com |
+| Customer type | Region                  | Endpoint                   |
+| ------------- | ----------------------- | -------------------------- |
+| All           | Global (lowest-latency) | global.rt.speechmatics.com |
+| All           | EU1 (Europe)            | eu.rt.speechmatics.com     |
+| All           | US1 (USA)               | us.rt.speechmatics.com     |
+
+`global.rt.speechmatics.com` automatically routes each connection to the lowest-latency region, so you do not have to choose one. The regional endpoints remain available if you want to pin to a specific region.
+
+:::warning
+`global.rt.speechmatics.com` may route a connection to any region. If you have data residency or compliance requirements, use a regional endpoint (`eu.rt.speechmatics.com` or `us.rt.speechmatics.com`) instead.
+:::
   </TabItem>
 </Tabs>
 

--- a/docs/get-started/authentication.mdx
+++ b/docs/get-started/authentication.mdx
@@ -89,7 +89,7 @@ Speechmatics Realtime SaaS supports the following endpoints for production use:
 
 | Customer type | Region                  | Endpoint                   |
 | ------------- | ----------------------- | -------------------------- |
-| All           | Global (lowest-latency) | global.rt.speechmatics.com |
+| All           | Global                  | global.rt.speechmatics.com |
 | All           | EU1 (Europe)            | eu.rt.speechmatics.com     |
 | All           | US1 (USA)               | us.rt.speechmatics.com     |
 

--- a/docs/get-started/authentication.mdx
+++ b/docs/get-started/authentication.mdx
@@ -34,7 +34,7 @@ curl -X GET "https://eu1.asr.api.speechmatics.com/v2/jobs/" \
   </TabItem>
   <TabItem value="real-time" label="Realtime transcription" default>
 
-For server-side calls, your API key must be provided in the header of the [Websocket connection request](/api-ref/realtime-transcription-websocket#handshake-responses). For example:
+For server-side calls, your API key must be provided in the header of the [WebSocket connection request](/api-ref/realtime-transcription-websocket#handshake-responses). For example:
 ```bash
 GET /v2/ HTTP/1.1
 Host: eu.rt.speechmatics.com
@@ -43,7 +43,7 @@ Connection: Upgrade
 Authorization: Bearer YOUR_API_KEY
 User-Agent: Python/3.8 websockets/8.1
 ```
-For client-side calls, we recommend using [temporary keys](#temporary-keys) (JWTs) to authenticate your requests. These can be passed as a query param to the [Websocket connection request](/api-ref/realtime-transcription-websocket#handshake-responses) URL. For example:
+For client-side calls, we recommend using [temporary keys](#temporary-keys) (JWTs) to authenticate your requests. These can be passed as a query param to the [WebSocket connection request](/api-ref/realtime-transcription-websocket#handshake-responses) URL. For example:
 
 ```bash
 wss://eu.rt.speechmatics.com/v2?jwt=$TEMP_KEY
@@ -87,11 +87,11 @@ The EU2 and US2 Batch SaaS endpoints are provided for enterprise customer high a
 
 Speechmatics Realtime SaaS supports the following endpoints for production use:
 
-| Customer type | Region                  | Endpoint                   |
-| ------------- | ----------------------- | -------------------------- |
-| All           | Global                  | global.rt.speechmatics.com |
-| All           | EU1 (Europe)            | eu.rt.speechmatics.com     |
-| All           | US1 (USA)               | us.rt.speechmatics.com     |
+| Customer type | Region       | Endpoint                       |
+| ------------- | ------------ | ------------------------------ |
+| All           | All regions  | **global.rt.speechmatics.com** |
+| All           | EU1 (Europe) | **eu.rt.speechmatics.com**     |
+| All           | US1 (USA)    | **us.rt.speechmatics.com**     |
 
 `global.rt.speechmatics.com` automatically routes each connection to the lowest-latency region, so you do not have to choose one. The regional endpoints remain available if you want to pin to a specific region.
 
@@ -154,7 +154,7 @@ curl -X GET "https://eu1.asr.api.speechmatics.com/v2/jobs/" \
   </TabItem>
   <TabItem value="realtime" label="Realtime transcription">
 
-For Realtime transcription, temporary keys allow the end-user to start a websocket connection with Speechmatics directly, without exposing your long-lived API key. This will reduce the latency of transcription, as well as development effort. 
+For Realtime transcription, temporary keys allow the end-user to start a WebSocket connection with Speechmatics directly, without exposing your long-lived API key. This will reduce the latency of transcription, as well as development effort. 
 
 A Realtime temporary key is not tied to a region. The same key works with any Realtime endpoint, including `global.rt.speechmatics.com`.
 
@@ -186,7 +186,7 @@ Note that when starting a Realtime transcription session in the browser, you mus
 |--------------|-----------|-----------------------------------------------------------
 | `ttl`        | Yes            | Integer: 60-86400. The temporary key's time to live in seconds. **Note** We suggest using the shortest TTL possible to minimise security risks.
 | `client_ref` | No             | String. When provided, `batch` tokens can only create and retrieve jobs with that reference; without it, they can access any job. **Must** be set when temporary keys are exposed to end-users to prevent accessing another user's data. `client_ref` is ignored when requesting `rt` tokens.
-| `region`     | No             | String: `eu` (default), `usa`, or `au` (Batch transcription only). Accepted for backward compatibility; temporary keys are no longer scoped to a region.
+| `region`     | No             | String: `eu` (default), `usa`, or `au` (Batch transcription only). Accepted for backward compatibility; the key is no longer scoped to a region. Batch jobs are still created in the region of the endpoint used.
 
 
 ## Next steps

--- a/docs/get-started/authentication.mdx
+++ b/docs/get-started/authentication.mdx
@@ -156,6 +156,8 @@ curl -X GET "https://eu1.asr.api.speechmatics.com/v2/jobs/" \
 
 For Realtime transcription, temporary keys allow the end-user to start a websocket connection with Speechmatics directly, without exposing your long-lived API key. This will reduce the latency of transcription, as well as development effort. 
 
+A Realtime temporary key is not tied to a region. The same key works with any Realtime endpoint, including `global.rt.speechmatics.com`.
+
 The example request below will create a temporary key which can be used to start any number of Realtime transcription settings for 60 seconds:
 
 ```bash
@@ -184,7 +186,7 @@ Note that when starting a Realtime transcription session in the browser, you mus
 |--------------|-----------|-----------------------------------------------------------
 | `ttl`        | Yes            | Integer: 60-86400. The temporary key's time to live in seconds. **Note** We suggest using the shortest TTL possible to minimise security risks.
 | `client_ref` | No             | String. When provided, `batch` tokens can only create and retrieve jobs with that reference; without it, they can access any job. **Must** be set when temporary keys are exposed to end-users to prevent accessing another user's data. `client_ref` is ignored when requesting `rt` tokens.
-| `region`     | No             | String: `eu` (default), `usa`, or `au` (Batch transcription only). Defines the region where the temporary key is valid.
+| `region`     | No             | String: `eu` (default), `usa`, or `au` (Batch transcription only). Accepted for backward compatibility; temporary keys are no longer scoped to a region.
 
 
 ## Next steps

--- a/docs/get-started/authentication.mdx
+++ b/docs/get-started/authentication.mdx
@@ -186,7 +186,7 @@ Note that when starting a Realtime transcription session in the browser, you mus
 |--------------|-----------|-----------------------------------------------------------
 | `ttl`        | Yes            | Integer: 60-86400. The temporary key's time to live in seconds. **Note** We suggest using the shortest TTL possible to minimise security risks.
 | `client_ref` | No             | String. When provided, `batch` tokens can only create and retrieve jobs with that reference; without it, they can access any job. **Must** be set when temporary keys are exposed to end-users to prevent accessing another user's data. `client_ref` is ignored when requesting `rt` tokens.
-| `region`     | No             | String: `eu` (default), `usa`, or `au` (Batch transcription only). Accepted for backward compatibility; the key is no longer scoped to a region.
+| `region`     | No             | **Deprecated.** String: `eu` (default), `usa`, or `au` (Batch transcription only). Region is determined by the endpoint you call, not the key. Still accepted for backward compatibility, but it has no effect.
 
 
 ## Next steps

--- a/docs/get-started/authentication.mdx
+++ b/docs/get-started/authentication.mdx
@@ -186,7 +186,7 @@ Note that when starting a Realtime transcription session in the browser, you mus
 |--------------|-----------|-----------------------------------------------------------
 | `ttl`        | Yes            | Integer: 60-86400. The temporary key's time to live in seconds. **Note** We suggest using the shortest TTL possible to minimise security risks.
 | `client_ref` | No             | String. When provided, `batch` tokens can only create and retrieve jobs with that reference; without it, they can access any job. **Must** be set when temporary keys are exposed to end-users to prevent accessing another user's data. `client_ref` is ignored when requesting `rt` tokens.
-| `region`     | No             | String: `eu` (default), `usa`, or `au` (Batch transcription only). Accepted for backward compatibility; the key is no longer scoped to a region. Batch jobs are still created in the region of the endpoint used.
+| `region`     | No             | String: `eu` (default), `usa`, or `au` (Batch transcription only). Accepted for backward compatibility; the key is no longer scoped to a region.
 
 
 ## Next steps

--- a/spec/mp.yaml
+++ b/spec/mp.yaml
@@ -336,8 +336,9 @@ definitions:
         type: string
         x-nullable: true
         description: >-
-          Deprecated. Region is determined by the endpoint you call, not the
-          key. Still accepted for backward compatibility, but it has no effect.
+          Deprecated. Region (`eu` (default), `usa`, or `au`) is now determined
+          by the endpoint you call. Still accepted for backward
+          compatibility, but it has no effect.
         enum:
           - eu
           - usa

--- a/spec/mp.yaml
+++ b/spec/mp.yaml
@@ -336,8 +336,8 @@ definitions:
         type: string
         x-nullable: true
         description: >-
-          The region where the key is valid: `eu` (default), `usa`, or `au`. The
-          `au` region supports Batch only, so it cannot be used with `type=rt`.
+          Deprecated. Region is determined by the endpoint you call, not the
+          key. Still accepted for backward compatibility, but it has no effect.
         enum:
           - eu
           - usa

--- a/spec/realtime.yaml
+++ b/spec/realtime.yaml
@@ -637,6 +637,11 @@ components:
             Only set when `type` is `concurrent_session_usage`. Indicates the timestamp of the most recent usage update, in the format `YYYY-MM-DDTHH:MM:SSZ` (UTC). This value is updated even when usage exceeds the quota, as it represents the most recent known data. In some cases, it may be empty or outdated due to internal errors preventing successful update.
           type: string
           example: "2025-03-25T08:45:31Z"
+        region:
+          description: >-
+            Only set when `type` is `concurrent_session_usage`. The region that reported this usage, for example `eu`. Present only when the cluster has a region configured, so it is omitted for on-premises and unconfigured deployments. Useful with the global endpoint (`global.rt.speechmatics.com`), which may route a connection to any region.
+          type: string
+          example: "eu"
       required:
         - message
         - type

--- a/spec/realtime.yaml
+++ b/spec/realtime.yaml
@@ -639,7 +639,7 @@ components:
           example: "2025-03-25T08:45:31Z"
         region:
           description: >-
-            Only set when `type` is `concurrent_session_usage`. The region that reported this usage, for example `eu`. Present only when the cluster has a region configured, so it is omitted for on-premises and unconfigured deployments. Useful with the global endpoint (`global.rt.speechmatics.com`), which may route a connection to any region.
+            Only set when `type` is `concurrent_session_usage`. The region that reported this usage, for example `eu`.
           type: string
           example: "eu"
       required:


### PR DESCRIPTION
## What

Documents the new **global** Realtime endpoint `global.rt.speechmatics.com` and the region-handling changes that come with it. The global endpoint is **additive** — the existing `eu.rt` / `us.rt` regional endpoints are unchanged — but the way region is selected has moved from the temporary key to the endpoint, so the temp-key `region` param is now deprecated.

Product behavior (routing, cross-region temp keys, residency) is sourced from the RT platform team via DEL-33644 / DEL-33774, not from `product-architecture.md`, which has no endpoint/region content.

## Changes

**Global endpoint**
- `docs/get-started/authentication.mdx` — adds `global.rt.speechmatics.com` to the Realtime "Supported endpoints" table, a one-line routing description, and a `:::warning` data-residency caveat (residency-sensitive customers should pin to a regional endpoint). Drops the now-redundant `Customer type` column from the Realtime table (all rows were `All`); kept on the Batch table where it still distinguishes All vs Enterprise.
- `docs/api-ref/realtime-transcription-websocket.mdx` — adds an `:::info` note that you can connect to `wss://global.rt.speechmatics.com/v2/`, linking to Supported endpoints as the authoritative source for the residency caveat (no duplication).

**Region param deprecation (DEL-33774)**
- `docs/get-started/authentication.mdx` — marks the temp-key `region` param **Deprecated**: region is now determined by the endpoint you call. Still accepted for backward compatibility, but has no effect.
- `spec/mp.yaml` — same deprecation on the `region` schema field.
- `docs/get-started/authentication.mdx` — notes that a Realtime temporary key is not tied to a region and works with any Realtime endpoint, including the global one.

**Usage message region field (DEL-33930)**
- `spec/realtime.yaml` — adds the `region` field to the `concurrent_session_usage` Info message, reporting which region served the usage. Useful with the global endpoint, which may route to any region.

**Drive-by cleanup**
- `docs/get-started/authentication.mdx` — `Websocket` → `WebSocket` (3 occurrences) per terminology.md.

## Validation

- `npm run build` passes; the new `#supported-endpoints` anchor resolves.
- `npm run spellcheck` clean.
