### PR TITLE
Add Administration docs group (DEL-32733)

### DIFF
--- a/docs/administration/accounts.mdx
+++ b/docs/administration/accounts.mdx
@@ -17,7 +17,7 @@ If your email address matches a [verified domain](/administration/domain-verific
 
 ## Sign-in methods
 
-You can sign in with email and password, or with a connected OAuth account. Speechmatics supports Google and GitHub. Manage connected accounts under **Settings > Profile > User**.
+You can sign in with email and password, or with a connected OAuth account. Speechmatics supports Google and GitHub. Manage connected accounts under **[Settings > Profile > User](https://portal.speechmatics.com/settings/profile/user)**.
 
 The available sign-in methods are determined by your workspace. If your workspace has [SSO](/administration/sso) enabled, sign in through your identity provider instead.
 
@@ -37,7 +37,7 @@ Deleting your account is permanent. You will no longer be able to create an acco
 2. In the **Delete account** section, click **Delete account**.
 3. Confirm the deletion.
 
-You cannot delete your account while you are an Admin in any workspace. Transfer Admin access to another member first, or contact [support@speechmatics.com](mailto:support@speechmatics.com).
+You cannot delete your account while you are an Admin in multiple workspaces. Transfer Admin access to another member first, or contact [support@speechmatics.com](mailto:support@speechmatics.com).
 
 ## Next steps
 

--- a/docs/administration/accounts.mdx
+++ b/docs/administration/accounts.mdx
@@ -1,0 +1,45 @@
+---
+title: Accounts
+description: Sign up, manage sign-in methods, update your profile and security settings, and delete your account.
+---
+
+# Accounts
+
+An account is your individual identity on the Speechmatics platform. Accounts belong to one or more [workspaces](/administration/workspaces-concepts), where you act as either an Admin or a Member.
+
+## Sign up and verification
+
+1. Go to [portal.speechmatics.com/signup](https://portal.speechmatics.com/signup).
+2. Sign up with email and password, or with a supported OAuth provider (Google or GitHub).
+3. If you signed up with email, verify your email address using the link sent to your inbox.
+
+If your email address matches a [verified domain](/administration/domain-verification), you join that workspace automatically. Otherwise, a new workspace is created for you.
+
+## Sign-in methods
+
+You can sign in with email and password, or with a connected OAuth account. Speechmatics supports Google and GitHub. Manage connected accounts under **Settings > Profile > User**.
+
+The available sign-in methods are determined by your workspace. If your workspace has [SSO](/administration/sso) enabled, sign in through your identity provider instead.
+
+## Profile and security
+
+Go to **Settings > Profile** in the portal to manage your account.
+
+- **User**: update your name, view your email address, and manage connected OAuth accounts.
+- **Security**: change your password and manage multi-factor authentication (MFA).
+- **Signed-in devices**: view active sessions and sign out of individual devices or all other devices at once.
+
+## Delete your account
+
+Deleting your account is permanent. You will no longer be able to create an account with the same email address.
+
+1. Go to **Settings > Profile > User**.
+2. In the **Delete account** section, click **Delete account**.
+3. Confirm the deletion.
+
+You cannot delete your account while you are an Admin in any workspace. Transfer Admin access to another member first, or contact [support@speechmatics.com](mailto:support@speechmatics.com).
+
+## Next steps
+
+- [Workspaces concepts](/administration/workspaces-concepts): how workspaces organize members, projects, and billing.
+- [Single sign-on (SSO)](/administration/sso): sign in through your organization's identity provider.

--- a/docs/administration/api-keys.mdx
+++ b/docs/administration/api-keys.mdx
@@ -1,0 +1,53 @@
+---
+title: API keys
+description: Create, view, and revoke the API keys that authenticate your applications to Speechmatics.
+---
+
+# API keys
+
+An API key authenticates requests to the Speech to Text and Text to Speech APIs. Each key is scoped to a single [project](/administration/projects): it can access only the transcripts produced within that project. For how keys are used in requests, see [Authentication](/get-started/authentication).
+
+API keys differ from [management tokens](/administration/management-tokens). API keys authenticate transcription and synthesis requests and are scoped to a project. Management tokens authenticate workspace administration and are scoped to the workspace.
+
+## Create an API key
+
+API keys are created within your active project. To create a key in a different project, switch projects first. See [Projects](/administration/projects#switch-between-projects).
+
+1. Go to **API keys** in the sidebar under **Projects**.
+2. Click **Create new key**.
+3. Enter a descriptive name for the key.
+4. Click **Generate new key**.
+5. Copy the key value from the dialog.
+
+:::warning
+You cannot access the key value again after closing this dialog. Store it in a secure location immediately.
+:::
+
+## Revoke an API key
+
+Revoking a key disables it immediately. Requests made with the key are rejected, which may break any application that depends on it.
+
+1. Go to **API keys** in the sidebar under **Projects**.
+2. Click the delete button next to the key.
+3. Confirm the removal.
+
+## Manage API keys with the API
+
+You can manage API keys programmatically with the Management API, authenticated with a [management token](/administration/management-tokens). Available operations include:
+
+- [Get all API keys](/api-ref/management/get-all-api-keys)
+- [Create an API key](/api-ref/management/create-an-api-key)
+- [Delete an API key](/api-ref/management/delete-an-api-key)
+
+## API key best practices
+
+- **Use descriptive names.** Name keys after the application or environment that uses them, so you can audit and revoke the right key later.
+- **Scope keys to projects.** Create keys in the project that matches their purpose to keep transcripts and usage isolated.
+- **Rotate keys periodically.** Create a replacement key, update your application, then revoke the old one.
+- **Revoke unused keys.** Remove any key that is no longer in use.
+
+## Next steps
+
+- [Authentication](/get-started/authentication): how to use API keys in requests.
+- [Projects](/administration/projects): scope keys by creating them in the right project.
+- [Management tokens](/administration/management-tokens): automate key management programmatically.

--- a/docs/administration/billing.mdx
+++ b/docs/administration/billing.mdx
@@ -1,0 +1,47 @@
+---
+title: Billing
+description: Manage your Pro payment card, and view and download invoices.
+---
+
+# Billing
+
+On the Billing page you add or manage your payment card and review what you have been charged. Free users add a card here to upgrade to Pro. Managing billing requires the Admin role.
+
+:::info
+Enterprise billing is handled through a contract, not a payment card. The card and invoices described here apply to the Pro plan only. See [Enterprise](/administration/plans#enterprise).
+:::
+
+## Add or edit a payment card
+
+Adding a card upgrades a Free plan to Pro. See [Plans](/administration/plans).
+
+1. Go to **Billing** in the sidebar under **Workspace**.
+2. In the **Payment method** section, click **Add payment card**, or **Edit payment information** if you already have a card.
+3. Enter your card details.
+4. Save your changes.
+
+## Remove a payment card
+
+:::warning
+Removing your payment card downgrades your plan to Free. Usage beyond the Free allowance stops being available.
+:::
+
+1. In the **Payment method** section, click the delete icon next to your card.
+2. Confirm the removal.
+
+## Invoices and payments
+
+The **Payments** section lists each billing period with its usage, cost, and status. Pro plans are billed on the first of each month for the previous month's usage. For how charges are calculated, see [Plans](/administration/plans#upgrade-to-pro).
+
+A billing period has one of the following statuses:
+
+- **Paid.** The charge has been settled.
+- **Due.** The charge is outstanding.
+- **Skipped.** No charge was raised for the period.
+
+To view and download the invoice for a period, click the link icon at the end of its row.
+
+## Next steps
+
+- [Plans](/administration/plans): how Free, Pro, and Enterprise billing works.
+- [Usage](/administration/usage): see a detailed breakdown of usage by mode and model.

--- a/docs/administration/domain-verification.mdx
+++ b/docs/administration/domain-verification.mdx
@@ -1,0 +1,30 @@
+---
+title: Domain verification
+description: Verify a domain so users from your organization join your workspace automatically.
+---
+
+# Domain verification
+
+Once a domain is verified, anyone signing up with an email address on that domain is added to your workspace as a Member. Domain verification requires the Admin role.
+
+## Verify a domain
+
+1. Go to **Manage workspace** in the sidebar under **Workspace**.
+2. In the **Domain** section, click **Add domain**.
+3. Enter the domain you want to verify.
+4. Add the DNS TXT record shown to your domain's DNS settings.
+5. Return to the portal and click **Verify**.
+
+DNS propagation can take up to 24 hours. The domain status changes to **Verified** once the record is detected.
+
+## Remove a verified domain
+
+1. In the **Domain** section, click the delete icon next to the verified domain.
+2. Confirm the removal.
+
+Removing a domain stops new automatic joins. Existing members keep their access.
+
+## Next steps
+
+- [Manage members](/administration/manage-members): invite users manually or change their roles.
+- [Single sign-on (SSO)](/administration/sso): configure SSO for your workspace.

--- a/docs/administration/manage-members.mdx
+++ b/docs/administration/manage-members.mdx
@@ -1,0 +1,37 @@
+---
+title: Manage members
+description: Invite users to your workspace, change their roles, and remove access.
+---
+
+# Manage members
+
+Member management requires the Admin role. See [Workspaces concepts](/administration/workspaces-concepts#roles) for what each role can do.
+
+## Invite a user
+
+1. Go to **Manage workspace** in the sidebar under **Workspace**.
+2. In the **Users** section, click **Invite user**.
+3. Enter the user's email address.
+4. Select a role: **Admin** or **Member**.
+5. Click **Invite**.
+
+The invited user receives an email with a link to complete their account. Until they accept, they will not appear as an active member.
+
+## Change a user's role
+
+1. In the **Users** table, click the options menu (⋯) next to the user.
+2. Select **Edit role**.
+3. Choose the new role and confirm.
+
+## Remove a user
+
+Removing a user revokes their access to the workspace immediately. Any API keys they created stay in the workspace and continue to work, because keys belong to the workspace rather than the user. Revoke them separately if needed. See [API keys](/administration/api-keys).
+
+1. In the **Users** table, click the options menu (⋯) next to the user.
+2. Select **Remove user**.
+3. Confirm the removal.
+
+## Next steps
+
+- [Domain verification](/administration/domain-verification): let users from your organization join automatically.
+- [Single sign-on (SSO)](/administration/sso): configure SSO for your workspace.

--- a/docs/administration/management-tokens.mdx
+++ b/docs/administration/management-tokens.mdx
@@ -1,0 +1,68 @@
+---
+title: Management tokens
+description: Automate workspace administration with tokens that create projects and manage API keys programmatically.
+---
+
+# Management tokens
+
+## How management tokens work
+
+Management tokens authenticate programmatic access to workspace administration. Use them to automate project creation, API key management, and other workspace operations through the Management API.
+
+Tokens are scoped to the workspace and do not expire unless you revoke them. Each token can be assigned a subset of permissions, so you can limit access to only what your automation requires.
+
+### Permissions
+
+| Permission | Description |
+|---|---|
+| View projects | View projects created within your workspace. |
+| Manage projects | Manage, edit, and delete projects in your workspace. |
+| View API keys | View API keys generated in your workspace. |
+| Delete API keys | Delete API keys in your workspace. |
+| Create API key | Create API keys in your workspace. |
+
+## Create a management token
+
+1. Go to **Manage workspace** in the sidebar under **Workspace**.
+2. In the **Management tokens** section, click **+ Create management token**.
+3. Enter a descriptive name for the token.
+4. Select the permissions your automation needs.
+5. Click **Create management token**.
+6. Copy the token value from the **Save your key** dialog.
+
+:::warning
+You cannot access the token value again after closing this dialog. Store it in a secure location immediately.
+:::
+
+## View token details
+
+1. In the **Management tokens** table, click the options menu (⋯) next to the token.
+2. Select **View details**.
+
+The details panel displays the token name, key prefix, last used timestamp, assigned permissions, and creation date.
+
+## Revoke a management token
+
+Revoking a token disables it immediately. API requests made with the token are rejected, which may break any systems that depend on it.
+
+:::danger
+Revoking a management token cannot be undone.
+:::
+
+1. In the **Management tokens** table, click the options menu (⋯) next to the token.
+2. Select **Revoke key**.
+3. Review the token name and key in the confirmation dialog.
+4. Click **Revoke key** to confirm.
+
+## Management token best practices
+
+- **Limit permissions.** Assign only the permissions each token needs. A token that creates API keys does not need permission to delete them.
+- **Use descriptive names.** Name tokens after their purpose or the system that uses them, such as `ci-pipeline` or `key-rotation-script`. This makes it easier to audit and revoke the right token later.
+- **Rotate tokens periodically.** Create a replacement token, update your systems, then revoke the old one.
+- **Revoke unused tokens.** Check the **Last used** column regularly. Revoke any token that has never been used or has not been used recently.
+
+## Next steps
+
+- [Create an API key](/api-ref/management/create-an-api-key): Management API reference for creating keys programmatically.
+- [Projects](/administration/projects): create and manage projects.
+- [API keys](/administration/api-keys): how API keys differ from management tokens.

--- a/docs/administration/plans.mdx
+++ b/docs/administration/plans.mdx
@@ -21,22 +21,22 @@ Pro plans are billed on the first of each month for the previous month's usage. 
 
 ## Discounts
 
-Pro plans can access two discounts, which can be applied at the same time.
+Pro plans can access two discounts, which can be applied at the same time. For current discount rates, see the [pricing page](https://www.speechmatics.com/pricing).
 
 ### Model training discount
 
-Enable **Model training** to receive a 33% discount on your usage. Model training, also called data logging, lets Speechmatics use anonymized data to improve its models and services. You can change this setting at any time, and it applies to future usage only.
+Enable **Model training** to receive a discount on your usage. Model training, also called data logging, lets Speechmatics use anonymized data to improve its models and services. You can change this setting at any time, and it applies to future usage only.
 
 Enable **Model training** in **Manage workspace**.
 
 ### Volume discount
 
-A 20% volume discount applies automatically to billable usage above 500 hours per month, for each Speech to Text product type (a combination of processing mode and model, such as Realtime Enhanced).
+A volume discount applies automatically to billable usage above 500 hours per month, for each Speech to Text product type (a combination of processing mode and model, such as Realtime Enhanced).
 
 For example, if in one month you use 800 hours of Realtime Enhanced and 400 hours of Realtime Standard, you are billed as:
 
 - 500 hours of Realtime Enhanced at the base rate
-- 300 hours of Realtime Enhanced at the 20% discount
+- 300 hours of Realtime Enhanced at the discounted rate
 - 400 hours of Realtime Standard at the base rate
 
 ## Enterprise

--- a/docs/administration/plans.mdx
+++ b/docs/administration/plans.mdx
@@ -1,0 +1,57 @@
+---
+title: Plans
+description: Understand the Free, Pro, and Enterprise plans and how each one is billed.
+---
+
+# Plans
+
+Speechmatics offers two self-serve plans, Free and Pro, plus Enterprise for contract-based usage.
+
+- **Free.** Use Speechmatics up to a monthly allowance at no cost.
+- **Pro.** Pay-as-you-go billing beyond the Free allowance, with volume and model training discounts.
+- **Enterprise.** A contract-based plan with dedicated support and deployment options beyond the cloud. See [Enterprise](#enterprise).
+
+Prices are not listed here. For current rates, see the [Speechmatics pricing page](https://www.speechmatics.com/pricing).
+
+## Upgrade to Pro
+
+To upgrade from Free to Pro, add a payment card on the Billing page. See [Billing](/administration/billing).
+
+Pro plans are billed on the first of each month for the previous month's usage. Charges are calculated to the exact second, based on the per-hour rate for each product type. Pro usage is capped at 6,000 hours per month.
+
+## Discounts
+
+Pro plans can access two discounts, which can be applied at the same time.
+
+### Model training discount
+
+Enable **Model training** to receive a 33% discount on your usage. Model training, also called data logging, lets Speechmatics use anonymized data to improve its models and services. You can change this setting at any time, and it applies to future usage only.
+
+Enable **Model training** in **Manage workspace**.
+
+### Volume discount
+
+A 20% volume discount applies automatically to billable usage above 500 hours per month, for each Speech to Text product type (a combination of processing mode and model, such as Realtime Enhanced).
+
+For example, if in one month you use 800 hours of Realtime Enhanced and 400 hours of Realtime Standard, you are billed as:
+
+- 500 hours of Realtime Enhanced at the base rate
+- 300 hours of Realtime Enhanced at the 20% discount
+- 400 hours of Realtime Standard at the base rate
+
+## Enterprise
+
+Enterprise is a contract-based plan for organizations that need dedicated support or deployment options beyond the cloud. It is separate from the self-serve Free and Pro plans: billing is handled through a contract rather than pay-as-you-go, with no payment card or monthly portal billing.
+
+Enterprise includes:
+
+- **High-touch support.** Dedicated customer support, onboarding, and solutions engineering.
+- **On-prem and on-device deployment.** These deployment options are available only on Enterprise. See [Deployments](/deployments/).
+- The best available discounts and early access to new features.
+
+To discuss an Enterprise plan, [contact sales](https://www.speechmatics.com/speak-to-sales).
+
+## Next steps
+
+- [Billing](/administration/billing): add a payment card, and view invoices and payments.
+- [Usage](/administration/usage): track the hours that determine your charges.

--- a/docs/administration/projects.mdx
+++ b/docs/administration/projects.mdx
@@ -1,0 +1,57 @@
+---
+title: Projects
+description: Organize work inside a workspace, scope API keys to projects, and track usage per project.
+---
+
+# Projects
+
+A project is an organizational unit inside a [workspace](/administration/workspaces-concepts). API keys, the transcripts they produce, and any voice agent configurations belong to a project. Any member of the workspace can access any project within it.
+
+Each workspace starts with a default project, which cannot be deleted. A workspace can have up to 1000 projects. If you need more, use [temporary keys](/get-started/authentication) or contact [support@speechmatics.com](mailto:support@speechmatics.com).
+
+API keys are scoped to a single project: a key created in one project cannot access transcripts produced in another. Billing and usage are not segmented by project, though usage can be viewed per project. See [Usage](/administration/usage).
+
+## Common use cases
+
+- **Development workflows.** Separate environments such as development, staging, and production.
+- **Organization segmentation.** Monitor usage by product line, department, or business unit.
+- **Multi-client service providers.** Give each client their own API keys and isolate their transcripts and usage data.
+
+## Create a project
+
+1. Open the projects dropdown in the top navigation.
+2. Select **Create project**.
+3. Enter a descriptive name.
+4. Click **Create**.
+
+## Switch between projects
+
+Your active project is shown in the top navigation. Transcribing in the portal and managing API keys both apply to the active project.
+
+1. Click the projects dropdown.
+2. Select a project.
+
+When using the API, you do not specify a project. Each API key is tied to one project, so the key determines which project a request applies to.
+
+## Rename or delete a project
+
+Manage projects under **Settings > Projects**. The project ID is read-only, and the default project cannot be deleted.
+
+:::danger
+Deleting a project permanently removes all of its transcripts, usage history, and API keys. This cannot be undone.
+:::
+
+## Manage projects with the API
+
+You can manage projects programmatically with the Management API, authenticated with a [management token](/administration/management-tokens). Available operations include:
+
+- [Get all projects](/api-ref/management/get-all-projects)
+- [Get a project by ID](/api-ref/management/get-a-project-by-id)
+- [Create a project](/api-ref/management/post-a-new-project)
+- [Update a project](/api-ref/management/update-a-project)
+- [Delete a project](/api-ref/management/delete-a-project)
+
+## Next steps
+
+- [API keys](/administration/api-keys): create and scope keys to a project.
+- [Usage](/administration/usage): track usage for a single project or across the workspace.

--- a/docs/administration/regions.mdx
+++ b/docs/administration/regions.mdx
@@ -1,0 +1,44 @@
+---
+title: Regions
+description: Choose where Speechmatics processes your audio, and understand what is stored in each processing mode.
+---
+
+# Regions
+
+A region is the location where your audio is processed. Each region is reached through its own API endpoint, so the region you use is determined by the endpoint you call. For the endpoint hostnames, see [supported endpoints](/get-started/authentication#supported-endpoints).
+
+Whether anything is stored in that region depends on the processing mode. See [What is stored](#what-is-stored).
+
+## Available regions
+
+The following regions are available to all customers:
+
+- **EU1** (Europe)
+- **US1** (United States)
+- **AU1** (Australia), which supports Batch only
+
+Realtime is available in EU1 and US1. Batch is available in all three regions.
+
+## What is stored
+
+What Speechmatics stores in a region depends on the processing mode:
+
+- **Realtime.** Audio is streamed over a WebSocket and is never recorded or stored. Transcripts are streamed back as they are produced and then discarded. Processing happens in memory.
+- **Batch.** Audio files, transcripts, and job configuration are stored for 7 days, then deleted automatically. You can delete them sooner with the API. See [Delete a job](/api-ref/batch/delete-a-job).
+
+## Select a region
+
+In the portal, use the **Region** selector in the top navigation. Your selection sets the region for transcription started from the portal.
+
+When using the API, the endpoint you call determines the region. A job is created in the region of the endpoint used, and all requests relating to that job must use the same endpoint.
+
+## Use multiple regions
+
+You can use more than one region to balance load or to fail over if one region is disrupted. Because each job belongs to the region it was created in, retrieve a job from the same region that created it.
+
+Enterprise customers may have region arrangements set in their contract. To use a different region, contact your account manager or [support](https://support.speechmatics.com).
+
+## Next steps
+
+- [Supported endpoints](/get-started/authentication#supported-endpoints): the endpoint hostname for each region.
+- [Usage](/administration/usage): track usage across your workspace.

--- a/docs/administration/security-and-compliance.mdx
+++ b/docs/administration/security-and-compliance.mdx
@@ -1,0 +1,30 @@
+---
+title: Security and compliance
+description: Find Speechmatics security certifications and request compliance documentation.
+---
+
+# Security and compliance
+
+Speechmatics maintains the following certifications and compliance standards:
+
+- ISO/IEC 27001:2022
+- SOC 2 Type II
+- GDPR
+- HIPAA
+
+For an overview of how Speechmatics protects your data, see the [security page](https://www.speechmatics.com/security).
+
+## Request documentation
+
+Security and compliance documentation, including certificates and reports, is distributed through the [Speechmatics Trust Center](https://speechmatics.safebase.us/).
+
+To access documentation, request access in the Trust Center, agree to the non-disclosure agreement, and download the documents you need. Access is reviewed and granted by the Speechmatics security team.
+
+## Data handling
+
+How long your data is stored depends on the processing mode. Realtime audio and transcripts are never stored, and Batch data is retained for 7 days. For details, see [What is stored](/administration/regions#what-is-stored).
+
+## Next steps
+
+- [Security page](https://www.speechmatics.com/security): how Speechmatics secures your data.
+- [Trust Center](https://speechmatics.safebase.us/): request certificates and compliance reports.

--- a/docs/administration/sidebar.ts
+++ b/docs/administration/sidebar.ts
@@ -1,0 +1,79 @@
+export default {
+  type: "category",
+  label: "Administration",
+  collapsible: false,
+  collapsed: false,
+  items: [
+    {
+      type: "doc",
+      label: "Accounts",
+      id: "administration/accounts",
+    },
+    {
+      type: "category",
+      label: "Workspaces",
+      items: [
+        {
+          type: "doc",
+          label: "Workspaces concepts",
+          id: "administration/workspaces-concepts",
+        },
+        {
+          type: "doc",
+          label: "Manage members",
+          id: "administration/manage-members",
+        },
+        {
+          type: "doc",
+          label: "Domain verification",
+          id: "administration/domain-verification",
+        },
+        {
+          type: "doc",
+          label: "Single sign-on (SSO)",
+          id: "administration/sso",
+        },
+      ],
+    },
+    {
+      type: "doc",
+      label: "Projects",
+      id: "administration/projects",
+    },
+    {
+      type: "doc",
+      label: "API keys",
+      id: "administration/api-keys",
+    },
+    {
+      type: "doc",
+      label: "Management tokens",
+      id: "administration/management-tokens",
+    },
+    {
+      type: "doc",
+      label: "Billing",
+      id: "administration/billing",
+    },
+    {
+      type: "doc",
+      label: "Plans",
+      id: "administration/plans",
+    },
+    {
+      type: "doc",
+      label: "Usage",
+      id: "administration/usage",
+    },
+    {
+      type: "doc",
+      label: "Regions",
+      id: "administration/regions",
+    },
+    {
+      type: "doc",
+      label: "Security and compliance",
+      id: "administration/security-and-compliance",
+    },
+  ],
+} as const;

--- a/docs/administration/sso.mdx
+++ b/docs/administration/sso.mdx
@@ -1,0 +1,30 @@
+---
+title: Single sign-on (SSO)
+description: Configure single sign-on for your workspace so users authenticate through your identity provider.
+---
+
+# Single sign-on (SSO)
+
+SSO lets users sign in to Speechmatics using your existing identity provider, such as Okta, Azure AD, or Google Workspace. Authentication is delegated to the provider; Speechmatics does not store user passwords for SSO users.
+
+:::info
+SSO is an add-on service with a separate subscription. To enable SSO for your workspace, contact [support@speechmatics.com](mailto:support@speechmatics.com).
+:::
+
+## Supported protocols
+
+Speechmatics supports SSO through [WorkOS AuthKit](https://workos.com/docs/sso):
+
+- SAML 2.0
+- OpenID Connect (OIDC)
+
+## Configure SSO
+
+Once SSO is enabled for your workspace by Speechmatics support, follow the provider-specific setup instructions to exchange metadata between your identity provider and Speechmatics.
+
+Configuration requires the Admin role.
+
+## Next steps
+
+- [Domain verification](/administration/domain-verification): verify your domain so SSO users join your workspace automatically.
+- [Manage members](/administration/manage-members): assign roles to users who join through SSO.

--- a/docs/administration/usage.mdx
+++ b/docs/administration/usage.mdx
@@ -1,0 +1,36 @@
+---
+title: Usage
+description: Track transcription usage by processing mode and model in the portal and through the API.
+---
+
+# Usage
+
+:::info
+Usage reporting in the portal covers cloud usage only. On-prem deployments report usage differently. See [on-prem usage reporting](/deployments/usage-reporting/).
+:::
+
+## View usage in the portal
+
+1. Go to **Usage** in the sidebar under **Workspace**.
+2. Select a time range, such as **7D**, **30D**, or **Custom**.
+3. Use the **All projects** dropdown to view usage for a single [project](/administration/projects) or across the workspace.
+
+Usage is shown in two charts, **Realtime** and **Batch**, matching the processing mode of each request. Each chart breaks usage down by model and reports total time used and request count.
+
+## Usage by model
+
+The models shown depend on the processing mode:
+
+- **Realtime**: Standard and Enhanced.
+- **Batch**: Standard, Enhanced, and Melia 1.
+
+Medical and agent variants are reported under their underlying model, not as separate lines. For example, Batch usage on the medical variant appears under Enhanced.
+
+## Track usage with the API
+
+To retrieve usage data programmatically, use the Usage API. See [Get usage statistics](/api-ref/batch/get-usage-statistics) in the API reference for endpoint details.
+
+## Next steps
+
+- [Billing](/administration/billing): understand how usage translates into charges.
+- [Projects](/administration/projects): organize work to track usage separately.

--- a/docs/administration/usage.mdx
+++ b/docs/administration/usage.mdx
@@ -30,6 +30,8 @@ Medical and agent variants are reported under their underlying model, not as sep
 
 To retrieve usage data programmatically, use the Usage API. See [Get usage statistics](/api-ref/batch/get-usage-statistics) in the API reference for endpoint details.
 
+The Usage API currently reports Batch usage only.
+
 ## Next steps
 
 - [Billing](/administration/billing): understand how usage translates into charges.

--- a/docs/administration/workspaces-concepts.mdx
+++ b/docs/administration/workspaces-concepts.mdx
@@ -1,0 +1,50 @@
+---
+title: Workspaces concepts
+description: Understand how workspaces organize users, projects, billing, and access on the Speechmatics platform.
+---
+
+# Workspaces concepts
+
+A workspace is the top-level container for your team's use of Speechmatics. Members, projects, API keys, billing, and usage all sit inside a workspace. Anything you do in the portal and API happens within one workspace at a time.
+
+## What a workspace contains
+
+A workspace groups four things:
+
+- **Members.** Users who can sign in to the workspace, each with an assigned role.
+- **Projects.** Organizational units inside the workspace. API keys are created within projects, and usage can be viewed per project. See [Projects](/administration/projects).
+- **API keys and management tokens.** API keys are scoped to a project; [management tokens](/administration/management-tokens) are scoped to the workspace.
+- **Billing and usage.** Pricing plan, payment method, invoices, and aggregated usage belong to the workspace.
+
+## Switch between workspaces
+
+A user can belong to more than one workspace. Each workspace is independent: switching changes which members, projects, keys, and billing details you see.
+
+To switch, open the avatar menu in the portal sidebar and select a workspace from the list.
+
+## Roles
+
+Every member of a workspace has a role that determines what they can do.
+
+| Role | Capabilities |
+|---|---|
+| Admin | Full access to the workspace, including settings, billing, members, and projects. Can invite and remove members, create and delete projects and API keys, and rename the workspace. |
+| Member | Access to all workspace resources, including projects and usage. Cannot manage members, billing, or workspace settings. |
+
+For instructions on inviting members and changing roles, see [Manage members](/administration/manage-members).
+
+## Workspaces and authentication
+
+Speechmatics uses [WorkOS AuthKit](https://workos.com/docs/authkit) for identity and access. A Speechmatics workspace corresponds to a WorkOS Organization, and the Admin and Member roles correspond to the WorkOS organization roles `admin` and `member`. Sign-in methods, including OAuth and SSO, are configured per workspace.
+
+When you verify a domain, new users signing up with an email address on that domain are added to your workspace automatically. See [Domain verification](/administration/domain-verification).
+
+## Workspaces and regions
+
+A workspace is not tied to a single region. The [region](/administration/regions) you select determines which [endpoint processes](/get-started/authentication#supported-endpoints) a request, not where the workspace lives. Members of the same workspace can submit work to different regions.
+
+## Next steps
+
+- [Manage members](/administration/manage-members): invite users, change roles, and remove access.
+- [Domain verification](/administration/domain-verification): let users from your organization join your workspace automatically.
+- [Single sign-on (SSO)](/administration/sso): configure SSO for your workspace.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1,3 +1,4 @@
+import administrationSidebar from "./docs/administration/sidebar";
 import apiRefSidebar from "./docs/api-ref/sidebar";
 import deploymentsSidebar from "./docs/deployments/sidebar";
 import gettingStartedSidebar from "./docs/get-started/sidebar";
@@ -14,6 +15,7 @@ export default {
     voiceAgentsSidebar,
     integrationsAndSDKSidebar,
     deploymentsSidebar,
+    administrationSidebar,
     {
       type: "category",
       label: "Developer Resources",


### PR DESCRIPTION
## What

Adds a new top-level **Administration** navigation group to the docs, covering 13 pages that document the self-serve portal.

Ticket: https://speechmatics.atlassian.net/browse/DEL-32733

## Structure

Administration is a navigation-group label only (no landing page), placed between **Deployments** and **Developer Resources**:

- **Accounts**
- **Workspaces** (sub-group): Workspaces concepts · Manage members · Domain verification · Single sign-on (SSO)
- **Projects** · **API keys** · **Management tokens**
- **Billing** · **Plans** · **Usage**
- **Regions** · **Security and compliance**

All 13 pages live flat in `docs/administration/` (URLs `/administration/<page>`); the Workspaces grouping is expressed in `sidebar.ts` only and does not change URLs.

## Notes for reviewers

- Pages were validated against the project style guide, terminology, and product architecture.
- Intra-group and cross-section links were normalized to **site-relative paths** (e.g. `/administration/projects`, `/api-ref/management/create-an-api-key`) so they are covered by the broken-link check (`onBrokenLinks: "throw"`).
- `npm run build` passes with no broken links; `cspell` and `biome` are clean.
- A few figures (Pro 6,000 h/mo cap, 20%/33% discounts, region availability) should get a final product check before publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)