### PR TITLE
Documentation for synchronous api in batch saas

### DIFF
--- a/docs/speech-to-text/batch/output.mdx
+++ b/docs/speech-to-text/batch/output.mdx
@@ -25,6 +25,10 @@ Transcription jobs are processed asynchronously. You can check the status of a j
 You can also configure notifications to be sent to a webhook when a job is completed. See [Notifications](/speech-to-text/batch/notifications) for more details.
 :::
 
+:::tip
+Instead of polling, you can block on a single request until the result is ready with the `wait` parameter. See [Synchronous transcription](/speech-to-text/batch/synchronous).
+:::
+
 ## Check single job status
 
 If you wish to retrieve a particular job, you can do so using the job ID for up to 7 days, after which time it will be automatically deleted in accordance with our [Data Retention Policy](/speech-to-text/batch/limits#data-retention-limits).

--- a/docs/speech-to-text/batch/sidebar.ts
+++ b/docs/speech-to-text/batch/sidebar.ts
@@ -16,6 +16,10 @@ export default {
     },
     {
       type: "doc",
+      id: "speech-to-text/batch/synchronous",
+    },
+    {
+      type: "doc",
       id: "speech-to-text/batch/limits",
     },
     {

--- a/docs/speech-to-text/batch/synchronous.mdx
+++ b/docs/speech-to-text/batch/synchronous.mdx
@@ -1,0 +1,109 @@
+---
+sidebar_position: 3
+description: 'Block for a job result with the wait parameter instead of polling.'
+---
+
+import { Card, Link, Text, Flex, Button, Box, Grid } from '@radix-ui/themes'
+import { LinkCard } from "@site/src/theme/LinkCard";
+import { HelpCircle, BookOpen, FileAudio } from "lucide-react"
+
+# Synchronous transcription
+
+Batch jobs are processed asynchronously: you create a job, then [poll its status](/speech-to-text/batch/output) or [receive a notification](/speech-to-text/batch/notifications) when it finishes. The `wait` query parameter lets you block on a single request until the result is ready instead, which is convenient for short files and quick integrations.
+
+:::info
+`wait` is only available on Batch SaaS.
+:::
+
+## How `wait` works
+
+Add `wait=N` (a number of seconds) to a request. The request blocks until the job reaches a terminal state or `N` seconds elapse, whichever comes first. The limit is capped server-side, so a very large value is clamped. If the job hasn't finished when the wait elapses, the request returns the current state and you can send it again to keep waiting.
+
+`wait` is supported on three endpoints:
+
+- `POST /jobs` — create a job and wait for it to finish.
+- `GET /jobs/{id}` — wait for a job to reach a terminal state.
+- `GET /jobs/{id}/transcript` — wait for the transcript to become available.
+
+## Create and wait
+
+Add `wait` to `POST /jobs` to create a job and block for its result in one request. The response is always `201` (the job record is created) and adds a `status` field reporting the outcome:
+
+- **`created`**: the job is still running — the wait elapsed before it finished.
+- **`done`**: the job finished. The transcript is embedded best-effort (see below).
+- **`rejected`**: the job could not be processed.
+- **`deleted`**: the job was deleted while waiting.
+
+`status` is only set when you send `wait`, so the response schema is fully opt-in: omit `wait` and the response is unchanged.
+
+```bash
+API_KEY="YOUR_API_KEY"
+PATH_TO_FILE="example.wav"
+
+curl -L -X POST "https://eu1.asr.api.speechmatics.com/v2/jobs/?wait=30" \
+    -H "Authorization: Bearer ${API_KEY}" \
+    -F data_file=@${PATH_TO_FILE} \
+    -F config='{"type": "transcription","transcription_config": { "model": "enhanced","language": "en" }}'
+```
+
+### Embedded transcript
+
+On `done`, the transcript is returned best-effort under a key named after the requested `format`. Use the `format` query parameter to choose it — `json-v2` (default), `txt`, or `srt`:
+
+```bash
+curl -L -X POST "https://eu1.asr.api.speechmatics.com/v2/jobs/?wait=30&format=txt" \
+    -H "Authorization: Bearer ${API_KEY}" \
+    -F data_file=@${PATH_TO_FILE} \
+    -F config='{"type": "transcription","transcription_config": { "model": "enhanced","language": "en" }}'
+```
+
+```json
+{
+  "id": "a1b2c3d4e5",
+  "status": "done",
+  "txt": "Welcome to Speechmatics..."
+}
+```
+
+The transcript is best-effort: if the key is absent (for example, the transcript briefly lagged the `done` status), fall back to [`GET /jobs/{id}/transcript`](/api-ref/batch/get-the-transcript-for-a-transcription-job) to retrieve it.
+
+## Wait on an existing job
+
+Add `wait` to `GET /jobs/{id}` to block for a terminal state. The response is always `200` with the job in its current state, so a non-finishing wait returns the still-running job — retry to keep waiting.
+
+```bash
+curl -L -X GET "https://eu1.asr.api.speechmatics.com/v2/jobs/a1b2c3d4e5?wait=30" \
+    -H "Authorization: Bearer ${API_KEY}"
+```
+
+## Wait for the transcript
+
+Add `wait` to `GET /jobs/{id}/transcript` to block until the transcript is available. If it becomes ready within the wait, the response is `200` with the transcript; otherwise it returns the usual `404` (transcription not ready), which you can retry to keep waiting.
+
+```bash
+curl -L -X GET "https://eu1.asr.api.speechmatics.com/v2/jobs/a1b2c3d4e5/transcript?wait=30&format=txt" \
+    -H "Authorization: Bearer ${API_KEY}"
+```
+
+## Quicklinks
+
+<Grid columns={{initial: "1", md: "2"}} gap="3">
+  <LinkCard
+    title="Output"
+    description="Poll job status and load transcripts"
+    href="/speech-to-text/batch/output"
+    icon={<FileAudio/>}
+  />
+  <LinkCard
+    title="Notifications"
+    description="Receive job output on a webhook instead of polling"
+    href="/speech-to-text/batch/notifications"
+    icon={<HelpCircle/>}
+  />
+  <LinkCard
+    title="API reference"
+    description="Full details about the Batch API"
+    href="/api-ref/batch/create-a-new-job"
+    icon={<BookOpen/>}
+  />
+</Grid>

--- a/spec/batch.yaml
+++ b/spec/batch.yaml
@@ -47,6 +47,28 @@ paths:
             **Note**: Only available for on-prem
 
             JSON dictionary of processing settings for the job worker. Currently supports `parallel_engines` (integer), which controls the number of engines the worker can use in parallel for this job, and `user_id` (string), which is the user id for this job. Example: `{"parallel_engines": 4}`
+        - name: wait
+          in: query
+          type: integer
+          required: false
+          description: >-
+            **Note**: Only available for Batch SaaS.
+
+
+            Number of seconds to block before responding. When set, the request waits until the job reaches a terminal state or the wait elapses, whichever comes first (the limit is capped server-side). The response is always `201` and includes a `status` field reporting the outcome; on `done` the transcript is embedded best-effort under the key named after `format`. When omitted, the request returns immediately and `status` is not set, keeping the new schema fully opt-in.
+        - name: format
+          in: query
+          type: string
+          required: false
+          enum:
+            - json-v2
+            - txt
+            - srt
+          description: >-
+            **Note**: Only available for Batch SaaS.
+
+
+            Format of the transcript embedded in the response when the job finishes within `wait`. Defaults to `json-v2`. Has no effect unless `wait` is set.
       responses:
         "201":
           description: OK
@@ -159,6 +181,15 @@ paths:
           required: true
           type: string
           x-example: a1b2c3d4e5
+        - name: wait
+          in: query
+          type: integer
+          required: false
+          description: >-
+            **Note**: Only available for Batch SaaS.
+
+
+            Number of seconds to block before responding. When set, the request waits until the job reaches a terminal state or the wait elapses, whichever comes first (the limit is capped server-side). The response is always `200` with the job in its current state, so a non-finishing wait returns the still-running job and the request can be retried to keep waiting.
       responses:
         "200":
           description: OK
@@ -286,6 +317,15 @@ paths:
             - json-v2
             - txt
             - srt
+        - name: wait
+          in: query
+          type: integer
+          required: false
+          description: >-
+            **Note**: Only available for Batch SaaS.
+
+
+            Number of seconds to block before responding. When set, the request waits until the transcript becomes available or the wait elapses, whichever comes first (the limit is capped server-side). Returns `200` with the transcript if it becomes ready within the wait; otherwise the usual `404` (transcription not ready), which can be retried to keep waiting.
       responses:
         "200":
           description: OK
@@ -1107,6 +1147,25 @@ definitions:
         type: string
         description: >-
           The unique ID assigned to the job. Keep a record of this for later retrieval of your completed job.
+      status:
+        type: string
+        description: >-
+          **Batch SaaS only.** Outcome of the job, present only when the `wait` query parameter was set on the request. * `created` - the job is still running (the wait elapsed before it finished). * `done` - the job finished; the transcript is embedded best-effort under the `json-v2`, `txt`, or `srt` key. * `rejected` - the job could not be processed. * `deleted` - the job was deleted while waiting.
+        enum:
+          - created
+          - done
+          - rejected
+          - deleted
+      json-v2:
+        $ref: "#/definitions/RetrieveTranscriptResponse"
+      txt:
+        type: string
+        description: >-
+          The transcript in plain text, embedded best-effort when `status` is `done` and `format` is `txt`. If absent, retrieve it from `GET /jobs/{id}/transcript`.
+      srt:
+        type: string
+        description: >-
+          The transcript in SRT format, embedded best-effort when `status` is `done` and `format` is `srt`. If absent, retrieve it from `GET /jobs/{id}/transcript`.
     example:
       id: a1b2c3d4e5
   JobDetails:


### PR DESCRIPTION
Summary

  Documents the new synchronous wait API for Batch SaaS, which lets clients block on a single request for a job's
  result instead of polling. Covers the wait parameter across POST /jobs, GET /jobs/{id}, and GET
  /jobs/{id}/transcript.

  Spec changes (spec/batch.yaml)

  API reference pages are generated from this file.

  - POST /jobs: new wait (integer seconds, capped server-side) and format (json-v2 | txt | srt, default json-v2)
  query params. Extended CreateJobResponse with:
    - status — outcome reported only when wait is set, so the new schema is fully opt-in: created (still running /
  wait elapsed), done, rejected, or deleted.
    - json-v2 / txt / srt — on done, the transcript is embedded best-effort under the key named after format; if
  absent, clients fall back to GET /jobs/{id}/transcript.
  - GET /jobs/{id}: new wait param. Blocks up to N seconds for a terminal state; always returns 200 with the job in
  its current state, retryable to keep waiting.
  - GET /jobs/{id}/transcript: new wait param. Returns 200 with the transcript if it becomes ready within the wait;
  otherwise the usual 404, retryable.

  Narrative docs

  - New page Synchronous transcription (docs/speech-to-text/batch/synchronous.mdx) explaining wait across the three
  endpoints, the status outcomes, the embedded transcript and its best-effort fallback, with curl examples. Flagged
  Batch SaaS–only.
  - Added to the Batch sidebar after Output.
  - Cross-linked from Output.