### PR TITLE
Fix broken anchors on four docs pages

### DIFF
--- a/docs/deployments/container/batch-persistent-worker.mdx
+++ b/docs/deployments/container/batch-persistent-worker.mdx
@@ -74,7 +74,7 @@ When processing long audio jobs the benefits on RTF of the persistent batch work
 
 ## Submitting a job
 
-Once the worker is running and is available, submit jobs by making a `POST` request to `/v2/jobs` with an audio file and transcription config. The worker queues the job and returns a `job_id` immediately. You can poll [`GET /v2/jobs/{job_id}`](#get-v2jobsjob_id) for the job status, and fetch the transcript when the status changes to `DONE`.
+Once the worker is running and is available, submit jobs by making a `POST` request to `/v2/jobs` with an audio file and transcription config. The worker queues the job and returns a `job_id` immediately. You can poll [`GET /v2/jobs/{job_id}`](#job-api-reference) for the job status, and fetch the transcript when the status changes to `DONE`.
 
 <Tabs>
   <TabItem value="curl" label="curl" default>

--- a/docs/deployments/container/performance-and-cost.mdx
+++ b/docs/deployments/container/performance-and-cost.mdx
@@ -37,7 +37,7 @@ For GPU Operating Points, transcribers and inference servers were all run on a s
 
 ### Realtime transcription
 
-| Operating Point                            | [CPU Standard](./cpu-speech-to-text#realtime-transcription) | [CPU Enhanced](./cpu-speech-to-text#realtime-transcription) | [GPU Standard](./gpu-speech-to-text#batch-and-real-time-inference) | [GPU Enhanced](./gpu-speech-to-text#batch-and-real-time-inference) |
+| Operating Point                            | [CPU Standard](./cpu-speech-to-text#realtime-transcription) | [CPU Enhanced](./cpu-speech-to-text#realtime-transcription) | [GPU Standard](./gpu-speech-to-text#batch-and-realtime-inference) | [GPU Enhanced](./gpu-speech-to-text#batch-and-realtime-inference) |
 |--------------------------------------------|--------------|--------------|--------------|--------------|
 | Lowest Processing Cost (US ¢ per hour)     | 1.97         | 2.95         | 0.86         | 2.51         |
 | Cost vs. CPU Standard (%)                  | -            | 150%         | 44%          | 127%         |

--- a/docs/speech-to-text/formatting.mdx
+++ b/docs/speech-to-text/formatting.mdx
@@ -408,7 +408,7 @@ This configuration:
 The `sensitivity` parameter accepts values from 0 to 1. Higher values produce more punctuation in the output.
 
 :::warning
-Disabling punctuation may slightly reduce speaker diarization accuracy. See the [speaker diarization and punctuation](/speech-to-text/features/diarization#diarization-and-punctuation) section for details.
+Disabling punctuation may slightly reduce speaker diarization accuracy. See [speaker diarization](/speech-to-text/features/diarization) for details.
 :::
 
 ## Next steps

--- a/docs/speech-to-text/realtime/turn-detection.mdx
+++ b/docs/speech-to-text/realtime/turn-detection.mdx
@@ -39,7 +39,7 @@ End of utterance detection is a feature that allows you to detect when a person 
 End of utterance uses server-side word timings to detect periods without speech. The moment a word is detected on the server, a countdown begins.
 If a new word is detected, the countdown restarts.
 If the configured interval passes without another word being detected, an end of utterance is triggered.
-When this happens, the server sends a [final transcript](/speech-to-text/realtime/quickstart#final-transcripts) message to the client, followed by an extra `EndOfUtterance` message.
+When this happens, the server sends a [final transcript](/speech-to-text/realtime/quickstart#receiving-finals-and-partials) message to the client, followed by an extra `EndOfUtterance` message.
 
 ### Configuration
 


### PR DESCRIPTION
## What

Repoints four internal anchor links whose target headings no longer exist. Surfaced by `npm run build` (`onBrokenAnchors` warnings).

| Page | Before | After |
|---|---|---|
| `deployments/container/batch-persistent-worker.mdx` | `#get-v2jobsjob_id` | `#job-api-reference` |
| `deployments/container/performance-and-cost.mdx` | `#batch-and-real-time-inference` | `#batch-and-realtime-inference` |
| `speech-to-text/formatting.mdx` | `#diarization-and-punctuation` (removed) | links to the page root |
| `speech-to-text/realtime/turn-detection.mdx` | `#final-transcripts` | `#receiving-finals-and-partials` |

## Verification

- `npm run build` passes; the broken-anchor count drops to **0**.

Text-only link fixes; no content or structural changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)