### PR TITLE
Move data-retention detail from Regions to Security and compliance

### DIFF
--- a/docs/administration/regions.mdx
+++ b/docs/administration/regions.mdx
@@ -1,13 +1,13 @@
 ---
 title: Regions
-description: Choose where Speechmatics processes your audio, and understand what is stored in each processing mode.
+description: Choose where Speechmatics processes your audio across the available regions.
 ---
 
 # Regions
 
 A region is the location where your audio is processed. Each region is reached through its own API endpoint, so the region you use is determined by the endpoint you call. For the endpoint hostnames, see [supported endpoints](/get-started/authentication#supported-endpoints).
 
-Whether anything is stored in that region depends on the processing mode. See [What is stored](#what-is-stored).
+Whether anything is stored depends on the processing mode, not the region. See [Data handling](/administration/security-and-compliance#data-handling).
 
 ## Available regions
 
@@ -18,13 +18,6 @@ The following regions are available to all customers:
 - **AU1** (Australia), which supports Batch only
 
 Realtime is available in EU1 and US1. Batch is available in all three regions.
-
-## What is stored
-
-What Speechmatics stores in a region depends on the processing mode:
-
-- **Realtime.** Audio is streamed over a WebSocket and is never recorded or stored. Transcripts are streamed back as they are produced and then discarded. Processing happens in memory.
-- **Batch.** Audio files, transcripts, and job configuration are stored for 7 days, then deleted automatically. You can delete them sooner with the API. See [Delete a job](/api-ref/batch/delete-a-job).
 
 ## Select a region
 

--- a/docs/administration/security-and-compliance.mdx
+++ b/docs/administration/security-and-compliance.mdx
@@ -22,7 +22,10 @@ To access documentation, request access in the Trust Center, agree to the non-di
 
 ## Data handling
 
-How long your data is stored depends on the processing mode. Realtime audio and transcripts are never stored, and Batch data is retained for 7 days. For details, see [What is stored](/administration/regions#what-is-stored).
+How long your data is stored depends on the processing mode:
+
+- **Realtime.** Audio is streamed over a WebSocket and is never recorded or stored. Transcripts are streamed back as they are produced and then discarded. Processing happens in memory.
+- **Batch.** Audio files, transcripts, and job configuration are stored for 7 days, then deleted automatically. You can delete them sooner with the API. See [Delete a job](/api-ref/batch/delete-a-job).
 
 ## Next steps
 


### PR DESCRIPTION
## What

Relocates the **What is stored** content from `/administration/regions` into `/administration/security-and-compliance#data-handling`, where data handling belongs. Storage depends on the **processing mode, not the region**, so it was out of place on the regions page.

## Changes

- **security-and-compliance.mdx** — merged the Realtime/Batch retention detail into the **Data handling** section (kept its lead sentence, folded in the two detailed bullets, dropped the now-circular cross-link, kept the Delete a job link).
- **regions.mdx** — removed the **What is stored** section; repointed the intro to `/administration/security-and-compliance#data-handling`; trimmed the frontmatter description to drop the storage clause.

## Verification

- `npm run build` passes (`onBrokenLinks: "throw"`); the repointed link resolves and the `#what-is-stored` anchor no longer exists or is referenced.
- `grep -rn "what-is-stored" docs/` → nothing.
- cspell clean.

No redirect needed — the regions page still exists (only an in-page section moved), and Vercel redirects can't target URL fragments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)