### PR TITLE
Replace docs-style-guide.md with current source-of-truth version

### DIFF
--- a/custom-words.txt
+++ b/custom-words.txt
@@ -341,3 +341,7 @@ configmap
 sessiongroups
 melia
 مرحبا
+Diátaxis
+frontmatter
+Quickstarts
+codenames

--- a/docs-style-guide.md
+++ b/docs-style-guide.md
@@ -1,276 +1,475 @@
+<!-- cspell:ignore diarisation colour recognise -->
+
+# Speechmatics Docs Style Guide
+ 
+Source of truth for writing, structuring, and maintaining content on docs.speechmatics.com.
+ 
+**Scope:** docs.speechmatics.com only. Does not govern speechmatics.com, portal.speechmatics.com, or Confluence.
+ 
+**Owners:** Matt and Pete at DevX. Flag gaps or propose changes in the shared Claude project.
+ 
+**Using this guide:** Start with Content types before writing anything. Use the quality checklist in Governance before publishing.
+ 
 ---
-trigger: model_decision
-description: Apply this rule when working on .md or .mdx files in the docs folder of the docs repo
+ 
+# Core writing principles
+ 
+"✅" = do / "❌" = don't
+ 
 ---
-
-This guide will help you write clear, consistent, and user-friendly content for the Docs.
-
-Make it easier for readers to find what they need and understand how to use our products.
-
-* * * * *
-
-Glossary
-========
-
-The glossary defines key terms used throughout the documentation to help ensure clarity and consistency.
-
-### Batch
-
-The Speechmatics' API for transcribing pre-recorded audio files. It performs speech-to-text conversion on complete audio inputs and returns the full transcript upon completion of processing. It's designed for asynchronous use cases where low latency isn't required.
-
-Grammatical context:
-
--   **Batch** (capitalized) refers to the **Speechmatics' API product** for processing pre-recorded audio.
-
-    -   Example: *Submit your file to Batch to receive a complete transcript once processing is done.*
-
--   **batch** (lowercase) is a **generic term** referring to any method of grouped processing.
-
-    -   Example: *Queue multiple files for batch conversion over a more extended period.*
-
-### Batch job
-
-A request to the Batch API that processes a pre-recorded audio file and returns the full transcript once processing is complete.
-
-### Diarization
-
-The process of automatically segmenting audio by speaker identity.
-
-Note: Don’t swap in synonyms—always use diarization to ensure consistency.
-
-### On-prem
-
-It is short for *on-premises* (plural), not *on-premise* (singular), and refers to running Speechmatics technology within clients' own infrastructure, rather than using cloud-based APIs.
-
-### Realtime
-
-The Speechmatics' API for live transcription. It processes streaming audio input and returns transcription results as speech is received, enabling low-latency, continuous speech-to-text conversion for real-time applications.
-
-Grammatical context:
-
--   **Realtime** (capitalized, no hyphen) refers to the **name of the Speechmatics' API product** for transcription of streaming audio.
-
-    -   Example: *You can stream audio to Realtime to receive instant transcription results.*
-
--   **real-time** (hyphenated) is a **general-purpose adjective** describing processes or systems that operate with minimal delay.
-
-    -   Example: *The system returns real-time results.*
-
-### Realtime session
-
-A continuous transcription process where audio is streamed to the API and transcribed as it's received, enabling immediate feedback with low latency.
-
-### Speech to text
-
-A core software component or service that converts spoken audio into written text using Speechmatics' ASR models from streaming audio (Realtime) and pre-recorded files (Batch). It is Speechmatics' product group.
-
-Grammatical context:
-
--   **speech to text** (no hyphens) is typically used as an  **open compound noun phrase**.
-
-    -   Example: *Our platform supports speech to text and text to speech.*
-
--   **speech-to-text** (hyphenated) is used as a **compound modifier** before a noun.
-
-    -   Example: *We offer speech-to-text conversion for streaming media.*
-
-### Voice agents &ndash; Flow
-
-A platform for creating conversational AI agents that can understand and respond to users in natural, real-time conversations.
-
-Grammatical context:
-
--   Use an en dash (&ndash;) to indicate a connection between two equal terms in a name. Avoid using a hyphen (-) here&mdash;it suggests a single compound word rather than a title hierarchy&mdash;and steer clear of an em dash (&mdash;), which is too heavy for navigation items or section titles.
-
-* * * * *
-
-Core writing principles
-=======================
-
-## Dos and Don'ts
-
-The ✅ emoji precedes a correct use example. 
-
-The ❌ emoji precedes an incorrect use example.
-
-### Keep it concise
-
-Write clearly and avoid redundant language.
-✅ *Languages*
-❌ *Speechmatics supported languages*
-
-### American English
-
-Use en-US spelling and grammar conventions consistently.
-✅ *diarization and color*
-❌ *diarisation and colour*
-
-### Prioritise lowercase spelling
-
-Capitalize only proper nouns, like product names, to maintain a clear content hierarchy.
-✅ *Refer to the channel diarization guide for the Batch API.*
-❌ *For troubleshooting Containers, please refer to the On-Prem Documentation.*
-
-### Sentence case in titles and headings
-
-It is more elegant and less overbearing than title casing. Especially for longer titles. ([more tips](https://www.everyinteraction.com/articles/title-case-vs-sentence-case-in-ui/))
-
-✅ *Language identification*
-❌ *Supported Formats and Limits*
-
-### Human-centric
-
-Write in a way that includes readers with various levels of technical depth.
-
-### Jargon only when needed
-
-With inline definitions or cross-links to relevant pages.
-
-### Empathy and clarity
-
-Explain 'why' before 'how'.
-
-### Enterprise-ready
-
-Numbered sequences, modular sections, and cross-references to deeper specs.
-
-* * * * *
-
-Content framework
-=================
-
-Elements
---------
-
-### Navigation item name
-
-1 or 2-word names are preferred. Try to keep it under 3 words. Use 4 or more words only if no other choice is available. Use sentence case only.
-
-✅ *Language identification*
-❌ *Virtual Appliance Usage Reporting*
-
-### Page title
-
-It may differ from the corresponding navigation item title.
-Try to keep it under 5 words if possible.
-Use sentence case only.
-
-### Description
-
-A one-sentence benefit-led 'What you'll do*'* statement that sparks interest.
-Second person, active voice, present tense.
-
-✅ *Learn how to transcribe pre-recorded audio files.*
-✅ *Enable the model to fetch data and take actions.*
-✅ *Take your first steps with the Speechmatics API.*
-✅ *Explore speech features in the Speechmatics API.*
-✅ *Ensure the microphone input works correctly.*
-✅ *Allow Flow to use your custom LLM.*
-
-❌ *Speechmatics can turn audio into text.*
-❌ This is a quickstart guide for developers that shows how to transcribe.
-❌ *This page will give you comprehensive details on the API.*
-❌ *A quick overview of everything you might possibly need.*
-❌ *In-depth information and exhaustive guide.*
-❌ *Understand the concepts better with this detailed document.*
-❌ *We'll discuss several important aspects and usage examples.*
-❌ *Introduction and background to getting started with our features.*
-❌ *Explanation of how certain things can be done in our platform.*
-
-### Heading
-
-There is no word limit, but keep it concise and meaningful.
-Use the context to reduce the wording. Use sentence case only.
-
-✅ *Examples*
-❌ *Realtime output examples*
-
-### Paragraph
-
-Short paragraphs make content scannable and easy to digest. Respect readers' time and keep them to a maximum of 3 sentences long.
-
-**PRO TIP**
-Use your favourite LLM to paraphrase, shorten text, or suggest improvements. Share this guide or parts of it to provide the context.
-
-Visual hierarchy
-----------------
-
-Help readers find information quickly by organizing content into clear levels of text. Use the following principles:
-
--   **Headings** guide the eye and break up content into logical chunks.
-
--   **Subheadings** show relationships and group related ideas.
-
--   **Paragraphs** deliver detailed explanations under each heading.
-
-### Text styles and relationships
-
-1.  **Page title (H1)** -- the main topic, e.g., *Quickstart*.
-
-2.  **Section heading (H2)** -- key steps or concepts, e.g., *Realtime processing*.
-
-3.  **Subheading (H3+)** -- finer details within a section, e.g., *Operating points*.
-
-4.  **Paragraph** -- up to 3 sentences per paragraph.
-
-* * * * *
-
-Doc types
-=========
-
-Overview
---------
-
-Create an Overview for **every** product or top-level item that requires a definition (e.g., Flow or Container deployment). Provide readers with the big picture, the meaning, and help them decide whether to delve deeper or move on. Using these principles:
-
-1.  **Define core concepts**: List terms, such as *job* or *Flow engine*, with one-sentence definitions and links to the API reference if available.
-
-2.  **Include key use cases** (as bullets)
-
-3.  **High-level flow** (optional): A simple diagram or numbered list, e.g., for Send audio → Receive transcription.
-
-4.  **Point to next steps:** Link to any related content, e.g., *Quickstart, API reference,* or *Tutorials.*
-
-Quickstart
-----------
-
-The 'first sprint' for developers integrating the Speechmatics API. Guide users from zero to working code in under five minutes with these principles:
-
-1.  **Keep it concise and scannable**
-
-2.  **List actionable steps**
-
-3.  **Keep it code-first**: Show snippets before explaining them.
-
-4.  **Offer multi-platform examples**
-
-5.  **Include troubleshooting tips** and link to the error messages guide
-
-6.  **Point to next steps**: End with links to the complete API reference, tutorials, or SDK guides to sustain momentum.
-
-**Tips**
-
-**Time-to-first-value:** keep the entire Quickstart readable in 3--5 minutes.
-**Minimal prose:** code over paragraphs; use prose only to clarify 'why'.
-**Environment notes:** call out setup quirks as inline notes.
-**Consistency:** aim to use the same section order across all Quickstarts.
-
-Guide
------
-
-Guides walk readers through more detailed workflows or feature sets. They provide instructions, best practices, and deeper explanations.
-
-1.  **Organize into clear steps**: Break the procedure into numbered sections or headings, each covering a logical unit of work.
-
-2.  **Mix prose with code**: Introduce each step with a brief "why" (1--2 sentences), then show the code snippet that achieves it.
-
-3.  **Highlight essential details**: Use admonitions for notes, tips, and cautions (e.g., authentication quirks, rate limits). Admonitions follow the docusaurus layout, for example:
-:::info
-This is an admonition
+ 
+1. **Write concisely.** Remove words that add length without adding meaning. No imprecise qualifiers like "quickly" or "easily."
+❌ Speechmatics supported languages → ✅ Languages
+ 
+❌ Note that this command requires admin rights. → ✅ This command requires admin rights.
+ 
+---
+ 
+2. **American English.** Use en-US spelling and grammar throughout.
+❌ diarisation, colour, recognise → ✅ diarization, color, recognize
+ 
+---
+ 
+3. **Lowercase by default.** Capitalize named products and APIs only. Common nouns, feature descriptions, and deployment methods are lowercase.
+❌ For Troubleshooting Containers, see the On-Prem Deployments Documentation. → ✅ Refer to the channel diarization guide for the Batch API.
+ 
+---
+ 
+4. **Sentence case in headings.** Capitalize first word and proper nouns only.
+❌ Language Identification → ✅ Language identification
+ 
+❌ Supported Formats and Limits → ✅ Supported formats and limits
+ 
+---
+ 
+5. **Active voice.** The subject performs the action.
+❌ A job ID is returned by the API. → ✅ The API returns a job ID.
+ 
+❌ The webhook endpoint should be configured. → ✅ Configure the webhook endpoint.
+ 
+---
+ 
+6. **Second person for instructions.** Use "you." Not "the user" or "the developer."
+❌ The user can configure the timeout in the request body. → ✅ You can configure the timeout in the request body.
+ 
+Exception: reference content describing system behavior uses third person.
+ 
+---
+ 
+7. **Avoid filler phrases.**
+❌ Note that this command requires admin rights. → ✅ This command requires admin rights.
+❌ Please run the installer. → ✅ Run the installer.
+❌ Keep in mind that jobs expire after 24 hours. → ✅ Jobs expire after 24 hours.
+❌ It is important to configure authentication first. → ✅ Configure authentication first.
+❌ Be aware that transcripts may take longer for large files. → ✅ Transcripts may take longer for large files.
+❌ In order to start, install the package. → ✅ To start, install the package.
+❌ Basically / Simply / Just...
+ 
+---
+ 
+8. **Include the reader.** Write for developers at different familiarity levels. Offer paths for faster readers without excluding others.
+❌ Experts can ignore the basic setup and proceed directly to the advanced configuration. → ✅ If you're familiar with REST APIs, skip ahead to the request parameters.
+ 
+---
+ 
+9. **One sentence of context before a procedure.** A single sentence explaining why may precede the first step. More than one sentence belongs in an Explanation page, linked from the procedure.
+❌ [Multiple paragraphs before the first numbered step.] → ✅ To maintain data privacy, deploy on-prem. Follow these steps to configure your server.
+ 
+---
+ 
+10. **One step, one action.** Each numbered step covers exactly one action. Instruction before explanation within a step.
+❌ 1. Run the installer and enter your API key when prompted. → ✅ 1. Run the installer. 2. Enter your API key when prompted.
+ 
+❌ Because this sets up the required environment variables, run the installer. → ✅ Run the installer. This sets up the required environment variables.
+ 
+---
+ 
+11. **Define jargon at first use.** Choose format by complexity:
+- **Parenthetical:** for terms definable in a phrase. ✅ diarization (separating a transcript into individual speakers)
+- **Note admonition:** for terms needing a full sentence or more.
+- **Link:** for terms defined elsewhere. Link on first use; do not redefine inline.
+Do not define terms more recognizable than their definitions: API, JSON, SDK, REST, WebSocket.
+ 
+---
+ 
+# Content types
+ 
+Content types are authoring modes, not page templates. A page has a dominant mode but may move through multiple modes. Every section must serve one clear reader need.
+ 
+Derived from the [Diátaxis framework](https://diataxis.fr/).
+ 
+---
+ 
+## The arbitration rule
+ 
+Apply at every section, not just every page:
+ 
+:::info What is the reader trying to do right now?
+ 
+| The reader wants to... | Content type |
+|---|---|
+| Learn by doing and arrive at a working result | Tutorial |
+| Complete a specific real-world task | How-to guide |
+| Look up a fact, parameter, or specification | Reference |
+| Understand how or why something works | Explanation |
+ 
+If a section cannot be assigned to one of these, it is doing too many things. Split it.
+ 
 :::
-
-4.  **Include examples and expected results**
-
-5.  **Offer troubleshooting guidance:** Anticipate common errors at key steps and link to the error messages guide.
-
-6.  **If applicable, point to next steps**: At the end, point to the Quickstart, API reference, or deeper tutorials.
+ 
+---
+ 
+## When to blend, when to split
+ 
+A page may move through more than one content type.
+ 
+**The rule:** if an Explanation section is longer than the How-to section on the same page, the Explanation should be its own page.
+ 
+This applies in one direction only. A long Reference section on an otherwise task-oriented page does not trigger a split.
+ 
+---
+ 
+## Naming pages
+ 
+Content type labels do not appear in page titles.
+ 
+| Content type | Effective title patterns | Avoid |
+|---|---|---|
+| Tutorial | "Get started with...", "Build your first...", "Transcribe a file" | "Tutorial: ..." |
+| How-to guide | "Configure speaker diarization", "Authenticate with the API" | "Guide: ...", "How to guide: ..." |
+| Reference | "Batch API reference", "Configuration parameters", "Error codes" | "Reference: ..." |
+| Explanation | "How the Realtime API works", "Understanding diarization", "[Feature] concepts" | "Overview", "Introduction to...", "Explanation: ..." |
+ 
+---
+ 
+## Tutorial
+ 
+Teaches through doing. The reader follows a guided sequence and arrives at a working result. Learning-oriented; assumes minimal prior knowledge.
+ 
+Do not include background theory, design rationale, or optional variations. These belong in an Explanation.
+ 
+### Quickstart
+ 
+A Quickstart is a Tutorial scoped to first value only. Zero to working result in under five minutes.
+ 
+All Quickstarts must follow this format:
+ 
+1. **Time to first value:** fully readable and executable in 3–5 minutes.
+2. **Actionable and scannable:** numbered steps. No prose blocks before acting.
+3. **Code-first:** show the snippet before explaining it.
+4. **Multi-platform examples:** offer examples across platforms and environments where the API supports it.
+5. **Troubleshooting:** tips for the most common failure points; link to the error messages guide.
+6. **Consistent structure:** all Quickstarts follow the same section order.
+7. **Next steps:** end with a Next steps section.
+---
+ 
+## How-to guide
+ 
+Helps the reader accomplish a specific real-world task. The reader has baseline competence and needs the steps.
+ 
+Focus on steps only. Do not include conceptual background unless it directly affects the next action.
+ 
+:::tip
+If you find yourself writing "because" to explain a design decision, that content belongs in an Explanation. Move it there and link to it.
+:::
+ 
+---
+ 
+## Reference
+ 
+Factual information readers look up, not read. Neutral, consistent, complete.
+ 
+Includes: API endpoints and parameters, configuration schemas, error codes, language and model support tables, limits and quotas.
+ 
+Write as facts, not instructions. Every entry must be structurally consistent with every other entry of the same type.
+ 
+---
+ 
+## Explanation
+ 
+Context and reasoning behind how something works. The reader wants to understand, not act.
+ 
+Includes: how a product surface works, design rationale, comparisons, conceptual introductions.
+ 
+Do not label explanation pages as "Overview." Use a title that describes what the reader will understand: "How the Realtime API works", "Understanding speaker diarization", "[Feature] concepts."
+ 
+Do not include step-by-step instructions. Link to the relevant how-to guide or tutorial instead.
+ 
+---
+ 
+# Content elements
+ 
+---
+ 
+## Navigation item name
+ 
+1–2 words preferred. Maximum 3. Use 4 or more only when no shorter option is accurate. Sentence case only.
+ 
+❌ Virtual Appliance Usage Reporting → ✅ Usage reporting
+ 
+---
+ 
+## Page title (H1)
+ 
+The page's main topic. Maximum 5 words. Sentence case only. Must make sense out of context.
+ 
+❌ What Data Do We Record? → ✅ Data collection
+ 
+---
+ 
+## Description
+ 
+A single sentence summarizing what the reader will do or learn. Appears below the title. Also used as the frontmatter `description` field for search and AI retrieval.
+ 
+Second-person imperative, active voice, present tense, sentence case. Maximum 158 characters.
+ 
+✅ Learn how to transcribe pre-recorded audio files.
+✅ Enable the API to identify and label individual speakers in a transcript.
+✅ Take your first steps with the Speechmatics API.
+ 
+❌ This page will give you comprehensive details on the API.
+❌ Speechmatics can turn audio into text.
+❌ Introduction and background to getting started with Batch.
+ 
+---
+ 
+## Heading (H2)
+ 
+A concise label for a major section. Sentence case only. Must name the subject explicitly without relying on the page title for meaning.
+ 
+❌ Using it → ✅ Using the Realtime API
+❌ Configuration → ✅ Configure the Batch API timeout
+ 
+---
+ 
+## Subheading (H3+)
+ 
+Use for finer distinctions within a section. Never immediately follow a heading — always insert at least one paragraph of prose between an H2 and an H3.
+ 
+---
+ 
+## Visual hierarchy
+ 
+Use heading levels consistently. Do not skip levels: an H3 must sit inside an H2, not directly under an H1.
+ 
+| Level | Purpose | Example |
+|---|---|---|
+| H1 | Page topic. One per page. | *Speaker diarization* |
+| Description | Single sentence below H1. | *Enable the API to identify and label individual speakers.* |
+| H2 | Major section. Names a distinct topic or step. | *Configure speaker diarization* |
+| H3+ | Subdivision within an H2 section. | *Channel diarization* |
+| Paragraph | Body text. 1–3 sentences. One idea per paragraph. | |
+ 
+---
+ 
+## Paragraph
+ 
+1–3 sentences per paragraph. One idea per paragraph. Short paragraphs are easier to scan and improve AI retrieval chunking.
+ 
+---
+ 
+## Code snippet
+ 
+**Language annotation:** required. Specify the language after the opening backticks.
+ 
+**Context sentence:** required. Every snippet must be preceded by a sentence naming what the code does. Exception: Quickstarts use code-first order; the context sentence may follow. A snippet with no surrounding prose is not compliant.
+ 
+**Inline comments:** required. At least one inline comment per snippet identifying the purpose or a key step.
+ 
+**Length:** 10 lines or fewer for focused snippets. Add line numbers to longer or multi-step snippets.
+ 
+**Copy button:** every code block must have copy functionality enabled.
+ 
+---
+ 
+## Table
+ 
+Use for comparisons, structured properties, and listings where column relationships matter.
+ 
+- **Header row** (required): sentence case.
+- **Row striping:** alternating shading.
+- **Accessibility:** include a brief `aria-label` or caption.
+- **Size:** maximum 5 columns and 10 rows. Split larger datasets.
+- **Caption** (optional): one sentence, maximum 80 characters.
+---
+ 
+## Card
+ 
+A linked component surfacing a feature or guide. Every card is a link.
+ 
+- **Icon** (optional): 32×32px. Left of title for single-line descriptions; above title for multi-line.
+- **Title:** 2–4 words, 10–30 characters. Sentence case.
+- **Description:** maximum 80 characters. One sentence.
+Maximum 3 cards per row. Equal height across cards in the same row.
+ 
+---
+ 
+## Admonition
+ 
+Use only when content cannot be communicated in the main prose.
+ 
+**Frequency:**
+- Never place two admonitions adjacent to each other.
+- Warning and Danger: maximum one per page.
+- More than three admonitions on a page signals a structural problem.
+| Type | When to use | Tone |
+|---|---|---|
+| 🗒️ Note | Extra context not critical to the core content. | Clarify. |
+| 💡 Tip | Non-critical shortcuts or best practices. | Suggest. |
+| ℹ️ Info | Essential facts or background relevant to the subject. | Educate. |
+| ⚠️ Warning | Risks where a reader could make a consequential mistake. | Direct, factual. |
+| ⛔️ Danger | Critical risks, security issues, irreversible actions. | Firm. State the risk and a safe alternative. |
+ 
+---
+ 
+## Next steps
+ 
+End pages that need further signposting with an H2 titled *Next steps*. Choose one format; do not combine more than two.
+ 
+**Inline sentence:** one verb-led sentence with an embedded link. Maximum 150 characters. Use when only one related action is available.
+ 
+**Context summary:** up to 3 short sentences transitioning into a list or link.
+ 
+**Bullet list:** 3–5 verb-led phrases, each with an embedded link.
+ 
+**Link list:** 2–5 items.
+- Title link: 2–6 words, 10–30 characters.
+- Description (optional): 8–12 words, maximum 60 characters.
+---
+ 
+# AI-readability standards
+ 
+AI-readability is not a separate concern from good writing. Both require clear structure, consistent terminology, and content that makes sense without surrounding context.
+ 
+---
+ 
+## Frontmatter
+ 
+Every page requires `title` and `description` in frontmatter.
+ 
+`title` must accurately reflect the page content.
+ 
+`description` is a single benefit-led sentence. Same rules as the Description content element. Maximum 158 characters. Do not leave empty or auto-generated.
+ 
+```yaml
+---
+title: Configure speaker diarization
+description: Enable the Speechmatics API to identify and label individual speakers in a transcript.
+---
+```
+ 
+---
+ 
+## Headings
+ 
+Every heading must make sense without surrounding context.
+ 
+- Name the subject explicitly: "Configure the Batch API timeout" not "Configure the timeout."
+- No pronoun-dependent headings: "Using it" or "How this works" are not valid.
+- Scope matches content: a heading describes everything beneath it and nothing else.
+---
+ 
+## Sections and chunking
+ 
+Each H2 section must be independently coherent. A reader arriving at the section without reading the full page must be able to understand it.
+ 
+Name the subject in the opening sentence. Do not rely on the heading to carry the subject into the prose.
+ 
+❌ "It accepts the following parameters." → ✅ "The `transcribe()` method accepts the following parameters."
+ 
+One concept per H2 section. Avoid forward and backward references ("as mentioned above", "see the next section"). Link explicitly to the target section instead.
+ 
+---
+ 
+## Terminology consistency
+ 
+Use one term per concept. Do not introduce a term by one name and later refer to it by another on the same page. Full rules are in the terminology file.
+ 
+❌ "Speaker diarization separates a transcript... The diarisation feature can be enabled..." → ✅ "Speaker diarization (referred to as diarization throughout this page) separates a transcript into distinct speakers."
+ 
+---
+ 
+## Code context
+ 
+Every snippet requires a prose sentence naming what it does. This sentence is the retrieval context for AI systems.
+ 
+For all content types except Quickstarts, the context sentence precedes the snippet. For Quickstarts, it may follow.
+ 
+A snippet with no surrounding prose is not compliant, regardless of inline comments.
+ 
+---
+ 
+## Images and visual content
+ 
+AI systems cannot process images. Every image must have a text equivalent.
+ 
+**Alt text:** required on every image. Describes content and purpose, not appearance.
+ 
+❌ `alt="diagram"` → ✅ `alt="Sequence diagram showing the WebSocket handshake between client and the Realtime API"`
+ 
+**Diagrams:** must have accompanying prose conveying the same information. A reader who cannot see the diagram must lose nothing.
+ 
+**Screenshots:** must not carry essential text. Any UI label, error message, or value visible only in a screenshot must also appear in the surrounding prose.
+ 
+**Decorative images:** use `alt=""`.
+ 
+---
+ 
+# Governance
+ 
+---
+ 
+## Quality checklist
+ 
+Every page must satisfy the following before going live.
+ 
+**Structure**
+- Content type is identifiable (the arbitration rule passes)
+- Page title follows naming conventions
+- Frontmatter `description` is present and complete
+- Content is not duplicated on another page
+**Content**
+- All code snippets have a context sentence
+- All specialist terms are defined at first use or linked
+- No internal codenames, legacy product names, or deprecated terms
+- All images have descriptive alt text
+**Review**
+- Reviewed by at least one person who did not write it
+- All links checked and resolving correctly
+---
+ 
+## When not to create a new page
+ 
+**Would this content work as a section on an existing page?** If yes, add a section.
+ 
+**Does this content duplicate something covered elsewhere?** If yes, link to it.
+ 
+**Is this content a response to a single question in one specific context?** If yes, it belongs as an admonition or note within the relevant page.
+ 
+**Does this content only describe relationships between other pages?** If yes, it does not meet the content type standard.
+ 
+---
+ 
+## Ownership
+ 
+Every page has an owner responsible for keeping it accurate when the product changes.
+ 
+When a feature ships, changes, or is deprecated, the responsible team identifies affected pages and updates them before or at release. Documentation updates are not a post-release task.
+ 
+Structural decisions — content location, categorization, information architecture — are escalated to the docs platform owners: Matt and Pete at DevX. This responsibility will transfer to a Documentation Lead if that role is created.
+ 
+---
+ 
+## Outdated and deprecated content
+ 
+**Deprecated features:** mark explicitly with a note stating the replacement and a link to it.
+ 
+**Removed features:** update or remove the page. Do not leave pages describing functionality that no longer exists.
+ 
+**Stale content:** flag to Matt or Pete at DevX. Do not make unilateral updates to content you do not own.
+ 
+---
+ 
+## Proposing changes
+ 
+Contact Matt or Pete at DevX directly with the proposed edit and a one-sentence rationale. Do not edit the project files or instructions before the proposal has been approved!


### PR DESCRIPTION
## Summary

The `docs-style-guide.md` in the repo was an outdated draft. This PR replaces it with the current source-of-truth version (provided by Pete, DevX), which:

- Removes the deprecated **"Voice agents – Flow"** glossary entry and Flow example, resolving the contradiction with `.CLAUDE/context/terminology.md` (Flow must not appear in user-facing content)
- Adds the **Diátaxis content types** section (Tutorial / How-to guide / Reference / Explanation) with the arbitration rule, blend/split rule, and page naming patterns that `CLAUDE.md` references
- Adds **AI-readability standards** (frontmatter, heading self-sufficiency, chunking, code context, image text equivalents)
- Adds **Governance**: quality checklist, page ownership, deprecation handling, and change proposal process

## Housekeeping

- Added `Diátaxis`, `frontmatter`, `Quickstarts`, `codenames` to `custom-words.txt`
- Added a file-scoped `cspell:ignore` comment for `diarisation` / `colour` / `recognise`, which appear intentionally as ❌ examples — scoped to this file so UK spellings stay flagged everywhere else

`npx cspell docs-style-guide.md` passes with 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)