### PR TITLE
Update product-architecture.md to the revised STT decision tree

### DIFF
--- a/.CLAUDE/context/product-architecture.md
+++ b/.CLAUDE/context/product-architecture.md
@@ -2,7 +2,7 @@
 
 This file describes the Speechmatics applied product architecture for use as project context. Use it to ensure accuracy when writing or reviewing docs.
 
-Last updated: 22 June 2026.
+Last updated: 3 July 2026.
 
 ---
 
@@ -10,7 +10,7 @@ Last updated: 22 June 2026.
 
 STT is structured as a layered decision tree. Each layer resolves one choice, taking the reader from the general API down to a specific packaged product, with deployment as an orthogonal final choice.
 
-The layers are: API, processing mode, interaction pattern, model, modification, packaging, and deployment.
+The layers are: API, processing mode, interaction pattern, model variant, model sub-variant, packaging, and deployment.
 
 ### Level 0: API
 
@@ -27,49 +27,48 @@ How the API is consumed.
 
 How audio is presented to the API for processing. Available patterns depend on the processing mode.
 
-- Realtime: **Streaming** (from live audio input), **Voice agent transcription** (turn-based, from live audio input)
-- Batch: **Pre-recorded** (file-based asynchronous or synchronous using long-polling)
+- Realtime: **streaming** (from live audio input), **agent STT** (turn-based, from live audio input; coming soon)
+- Batch: **pre-recorded** (file-based, asynchronous or synchronous using long-polling)
 
-Voice agent transcription is delivered as a profile on the Realtime API, surfaced via sub-URL routing. It is not a separate API and not a separate model.
+agent STT is an interaction pattern on the Realtime API, purpose-built as the speech-to-text layer for voice-agent applications. It is coming soon. See "Notes for writers" for the distinction between agent STT and a voice agent.
 
-### Level 3: Model
+### Level 3: Model variant
 
-The model used to transcribe. Available models depend on the interaction pattern.
+The model used to transcribe. Available model variants depend on the interaction pattern.
 
-- Streaming: **Standard** (language packs architecture), **Enhanced** (language packs architecture)
-- Voice agent transcription: an Enhanced-backed conversational model variant
-- Pre-recorded: **Standard** (language packs architecture), **Enhanced** (language packs architecture), **Melia 1** (multilingual architecture)
+- streaming: **Standard**, **Enhanced**
+- agent STT: **Linden 1** (coming soon)
+- pre-recorded: **Standard**, **Enhanced**, **Melia 1**
 
 Notes:
-- Standard and Enhanced are operating points on the Ursa-2 model architecture. Standard prioritises turnaround and cost; Enhanced prioritises accuracy.
-- Melia 1 is the first model on the AED (Attention-based Encoder-Decoder) architecture. It is multilingual: no language pack selection, and it requires `"language": "multi"`. Batch only today; Realtime on the roadmap.
-- Variant names are generation-scoped. There is no "Standard AED" or "Enhanced AED". Future AED-architecture models will have their own variant names.
+- Standard prioritizes turnaround and cost; Enhanced prioritizes accuracy.
+- Melia 1 is multilingual: no language pack selection, and it requires `"language": "multi"`. Batch only today.
 
-### Level 4: Modification
+### Level 4: Model sub-variant
 
-An optional adjustment applied to a model for a use case or sector. Modifications are packaging components, not new models.
+A separately trained, use-case- or sector-specific extension of a parent model variant. A sub-variant is more than a packaging label, but it is not a standalone model variant of its own — it depends on its parent.
 
-- **Medical domain**: bundled configuration tuned for medical use cases. Available on Enhanced (both Streaming and Pre-recorded).
-- Most configurations have no modification.
+- **Medical**: tuned for medical use cases. Available on Enhanced (both streaming and pre-recorded).
+- Most model variants have no sub-variant.
 
 ### Level 5: Packaging
 
 The packaged product a customer selects and contracts against. These are the names currently in use.
 
-| Processing mode | Interaction pattern | Model | Modification | Current product name |
+| Processing mode | Interaction pattern | Model variant | Model sub-variant | Current product name |
 |---|---|---|---|---|
-| Realtime | Streaming | Standard | — | Realtime Standard |
-| Realtime | Streaming | Enhanced | — | Realtime Enhanced |
-| Realtime | Streaming | Enhanced | medical domain | Realtime Medical |
-| Realtime | Voice agent transcription | Enhanced-backed variant | — | Agent Transcription API v1 |
-| Batch | Pre-recorded | Standard | — | Batch Standard |
-| Batch | Pre-recorded | Enhanced | — | Batch Enhanced |
-| Batch | Pre-recorded | Enhanced | medical domain | Batch Medical |
-| Batch | Pre-recorded | Melia 1 | — | Batch Melia-1 |
+| Realtime | streaming | Standard | — | Realtime Standard |
+| Realtime | streaming | Enhanced | — | Realtime Enhanced |
+| Realtime | streaming | Enhanced | Medical | Realtime Enhanced Medical |
+| Realtime | agent STT | Linden 1 | — | Agent STT Linden 1 (coming soon) |
+| Batch | pre-recorded | Standard | — | Batch Standard |
+| Batch | pre-recorded | Enhanced | — | Batch Enhanced |
+| Batch | pre-recorded | Enhanced | Medical | Batch Enhanced Medical |
+| Batch | pre-recorded | Melia 1 | — | Batch Melia 1 |
 
 ### Level 6: Deployment
 
-Deployment is orthogonal to the layers above and applies to all packaged products: **SaaS on Cloud** and **on-prem**. See "Notes for writers" for On-device.
+Deployment is orthogonal to the layers above and applies to all packaged products: **SaaS on Cloud**, **on-prem**, and **on-device** (coming soon). See "Notes for writers" for on-device coverage.
 
 ---
 
@@ -98,10 +97,10 @@ The model ships with four English voices:
 
 ## Notes for writers
 
-- **Use current product names.** The packaging names in the table above (Realtime Standard, Batch Enhanced, and so on) are the names currently in use and the only ones to put in docs. A target naming scheme led by interaction pattern (Streaming, Pre-recorded) is anticipated but not live. Do not pre-empt the rename or mix the two schemes in a page.
+- **Use current product names.** The packaging names in the table above (Realtime Standard, Batch Enhanced, and so on) are the names currently in use and the only ones to put in docs. A target naming scheme led by interaction pattern (streaming, pre-recorded) is anticipated but not live. Do not preempt the rename or mix the two schemes in a page.
 - **STT and TTS are separate product lines.** They share the API-at-top pattern but their mid-level semantics differ. STT Level 1 is processing mode; TTS Level 1 is model. Do not assume a uniform level model across the two.
-- **Modifications live at Level 4**, between model and packaging. They are packaging on top of an existing model, not separately trained models.
-- **Voice agent transcription is an interaction pattern on the Realtime API**, delivered as a profile via sub-URL routing. It is not a separate API and not a separate model. The current docs surface it under Voice agents.
+- **Model sub-variants live at Level 4**, between model variant and packaging. A sub-variant (such as Medical) is a separately trained extension of its parent model variant, tuned for a use case or sector — more than a packaging label, but dependent on its parent rather than a standalone model.
+- **agent STT is an interaction pattern on the Realtime API for building voice agents.** It is coming soon, with model variant Linden 1 and packaged product Agent STT Linden 1. A *voice agent* is a full conversational pipeline (STT + LLM + STT) and is a distinct concept that Speechmatics does not sell. agent STT provides the STT layer only. Never describe a Speechmatics product as a "voice agent."
 - **Melia 1 is multilingual and Batch only today.** It requires `"language": "multi"` and has no language pack selection.
-- **Deployment is an orthogonal axis.** SaaS on Cloud and on-prem are the current surfaces. On-device exists but its feature coverage is currently narrower than Cloud and on-prem, and parts are not yet generally available; check current documentation before describing On-device support.
+- **Deployment is an orthogonal axis.** SaaS on Cloud and on-prem are the current surfaces. On-device is coming soon and its feature coverage is currently narrower than Cloud and on-prem; check current documentation before describing on-device support.
 - **The decision tree is a guide, not a strict path.** A reader's product selection may skip layers.

--- a/custom-words.txt
+++ b/custom-words.txt
@@ -341,3 +341,4 @@ configmap
 sessiongroups
 melia
 مرحبا
+Theo


### PR DESCRIPTION
## Summary

Aligns the canonical structure context file `.CLAUDE/context/product-architecture.md` with the revised Speech to Text architecture diagram. Scoped to the context file only (plus one dictionary entry).

**Level renames**
- L3 "Model" → **Model variant**
- L4 "Modification" → **Model sub-variant**, reframed as a *separately trained*, use-case/sector-specific extension of its parent variant — not merely a packaging component (corrects the prior "packaging, not separately trained models" wording)

**Models & interaction patterns**
- Interaction pattern "Voice agent transcription" → **agent STT** (coming soon)
- New model **Linden 1** on the agent STT branch; **Melia 1** retained on Batch
- Packaged products renamed: **Realtime Enhanced Medical**, **Batch Enhanced Medical**, **Agent STT Linden 1** (coming soon), **Batch Melia 1**

**Deployment**
- **on-device** promoted to a listed deployment option (coming soon), alongside SaaS on Cloud and on-prem

**Codenames removed**
- Dropped Ursa-2 / AED / "operating point" / "…architecture" framing, keeping the functional facts (Standard = speed/cost vs Enhanced = accuracy; Melia 1 multilingual, `"language": "multi"`, Batch-only)

**Writers' guardrail added**
- agent STT is Speechmatics' STT layer for *building* voice agents. A *voice agent* (STT + LLM + STT) is a distinct concept and **not** a Speechmatics product — the file now says never to describe a Speechmatics product as a "voice agent"

## Out of scope (tracked as follow-ups)

- `terminology.md`: canonical entries for the new names + reconcile the deprecated-Flow pointer
- Downstream docs (`docs/voice-agents/`, integrations, `docs/index.mdx`) and `spec/*.yaml`

## Verification

- `npx cspell` passes (added "Theo", a TTS voice name, to `custom-words.txt`)
- No `ursa` / `aed` / `operating point` strings remain
- Re-checked every level, label, and packaging name against the diagram

🤖 Generated with [Claude Code](https://claude.com/claude-code)