### PR TITLE
Improve the Management API reference (DEL-33108)

### DIFF
--- a/docs/api-ref/index.mdx
+++ b/docs/api-ref/index.mdx
@@ -31,7 +31,7 @@ Speechmatics offers flexible REST and Websocket APIs for transcription and voice
     href="https://portal.speechmatics.com/settings/api-keys/"
   />
   <LinkCard
-    title="Manage your account programmatically"
+    title="Manage projects and API keys programmatically"
     icon={<Settings2/>}
     href="/api-ref/management/create-an-api-key"
   />

--- a/spec/mp.yaml
+++ b/spec/mp.yaml
@@ -2,8 +2,10 @@ swagger: '2.0'
 info:
   title: Management API
   version: 1.0.0
-  description: >-
-    The management API is used to manage customers and contracts.
+  description: |
+    The Management API lets you manage projects and API keys in your workspace programmatically. Authenticate each request with a [management token](/administration/management-tokens), which is scoped to the workspace.
+
+    Use it to automate workspace administration, such as creating a project and issuing its API key from a CI pipeline. To get started, [create a management token](/administration/management-tokens), then call the endpoints below.
   contact:
     email: support@speechmatics.com
 basePath: /v1
@@ -44,6 +46,15 @@ paths:
             $ref: '#/definitions/ErrorResponse'
     post:
       summary: Create an API key
+      description: |
+        Create an API key in your workspace, authenticated with a [management token](/administration/management-tokens).
+
+        This endpoint issues two kinds of key:
+
+        - **Permanent key** — a long-lived key for a project. Set `project_id` (and optionally `name`) and omit `ttl`. Use this for a normal project API key.
+        - **Temporary key** — a short-lived key that expires automatically. Set `ttl` to the lifetime in seconds. Use temporary keys to authenticate end-user requests without exposing a long-lived key.
+
+        The `au` region supports Batch only, so it cannot be combined with `type=rt`.
       consumes:
         - application/json
       parameters:
@@ -51,11 +62,12 @@ paths:
           in: query
           required: false
           type: string
-          description: Set the product this token will be authorised to access. Defaults to batch.
+          description: >-
+            The product this key can access: `batch` (default), `rt` (Realtime),
+            or `tts` (Text to Speech).
           enum:
             - rt
             - batch
-            - flow
             - tts
         - name: body
           in: body
@@ -301,21 +313,31 @@ definitions:
       project_id:
         type: integer
         x-nullable: true
+        description: The project the API key belongs to. Set this to create a permanent key for a specific project.
       name:
         type: string
         x-nullable: true
         maxLength: 120
+        description: A display name for the API key (up to 120 characters).
       client_ref:
         type: string
         x-nullable: true
+        description: An end-user reference. For `batch` keys, it restricts the key to jobs created with the same `client_ref`; it is ignored for `rt` keys.
       ttl:
         type: integer
         x-nullable: true
         minimum: 60
         maximum: 86400
+        description: >-
+          Time to live for a temporary key, in seconds, from 60 (1 minute) to
+          86400 (24 hours). Set `ttl` to create a temporary key that expires
+          automatically; omit it to create a permanent key.
       region:
         type: string
         x-nullable: true
+        description: >-
+          The region where the key is valid: `eu` (default), `usa`, or `au`. The
+          `au` region supports Batch only, so it cannot be used with `type=rt`.
         enum:
           - eu
           - usa


### PR DESCRIPTION
## What & why

Improves clarity of the **Management API** reference group so a reader can understand how to generate tokens and use the API correctly. Addresses the reviewable (docs-side) acceptance criteria in [DEL-33108](https://speechmatics.atlassian.net/browse/DEL-33108).

All endpoint content is edited in `spec/mp.yaml` (the source of truth); the `docs/api-ref/management/*.api.mdx` pages are regenerated from it and are gitignored.

## Changes

**Create an API key endpoint (`spec/mp.yaml`)**
- Remove **`flow`** from the `type` enum — it's the deprecated conversational/voice product and per `terminology.md` must not be referenced. Enum is now `rt`, `batch`, `tts`, each named in the description.
- Add an endpoint **description** distinguishing the two uses: a **permanent** project key (set `project_id`, omit `ttl`) vs a **temporary** key (set `ttl`).
- Describe every `CreateApiKeysRequest` field:
  - `ttl` — "60 (1 minute) to 86400 (24 hours)"; set it for a temporary key, omit for a permanent key.
  - `region` — `au` supports **Batch only**, so it cannot be combined with `type=rt`.
  - plus `project_id`, `name`, `client_ref`.
- Rewrite the group overview (`info.description`) from the inaccurate "manage customers and contracts" to an accurate summary: manages projects and API keys, authenticated with a management token, with a getting-started pointer.

**Cross-links**
- Add reciprocal links between the Management API reference and `/administration/management-tokens`.
- `docs/api-ref/index.mdx`: clarify the landing card title to "Manage projects and API keys programmatically".

## Acceptance criteria

| # | Criterion | Resolution |
|---|---|---|
| 1 | Remove `flow` if deprecated | ✅ removed |
| 2 | Clarify TTL range | ✅ 60 (1 min) – 86400 (24 h) |
| 3 | TTL is for temporary keys | ✅ stated on field + endpoint |
| 4 | Normal project key confusion | ✅ permanent-key path documented first |
| 5 | `rt` + `au` behaviour | ✅ documented as unsupported (au = Batch only) |
| 8 | Where to start programmatically | ✅ overview + cross-links |

Criteria **#6 (simplify portal user journey)** and **#7 (add docs link in the portal)** are changes to the management workspace **portal UI**, not the docs — out of scope for this repo; routing to the portal team.

## Validation
- `npm run build:mp-api-ref` regenerates cleanly; verified `flow` is gone, enum is `["rt","batch","tts"]`, and all descriptions render.
- Full `npm run build` succeeds with **no broken-link errors**.
- Spellcheck introduces no new issues.

## Reviewer notes
- No page URLs change, so no redirects were needed.
- **Parked:** per-endpoint code samples (curl/Python authenticated with a management token) to further address #8 — can add on request.
- The `rt`+`au` behaviour is documented as a constraint based on existing region docs; the exact API error response is not asserted (can be added if engineering confirms it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)