### PR TITLE
Clarify Smart formatting, entity terminology, and language coverage

### DIFF
--- a/.CLAUDE/context/terminology.md
+++ b/.CLAUDE/context/terminology.md
@@ -106,6 +106,8 @@ Customer-facing features and concepts that appear in the docs. Lowercase as comm
 | language pack | Language Pack, languagepack | Lowercase. The model assets for a given language. |
 | language identification | Language Identification, LID | Lowercase. Define on first use if abbreviating; prefer the full form. |
 | feature discovery | Feature Discovery | Lowercase. The endpoint returning current capability metadata. |
+| smart formatting | numeral formatting, Smart Formatting | Lowercase. The feature that converts spoken entities (numbers, dates, currencies, times, measurements, and more) into their written form. Avoid "numeral formatting": it is too narrow, implying numbers only and excluding non-numeric entity classes such as dates, times, and email addresses. |
+| entity | Entity | Lowercase. A spoken value with a conventional written form (a number, date, currency, time, measurement, and so on) that smart formatting detects and converts. `enable_entities` exposes each entity's structure in the JSON output. |
 
 ---
 

--- a/docs/deployments/index.md
+++ b/docs/deployments/index.md
@@ -43,9 +43,9 @@ Feature availability varies depending on the deployment method you choose. Below
 | [Fetch URL](/speech-to-text/batch/input#fetch-url)                                    | Batch           | SaaS, On-Prem |
 | [Language identification](/speech-to-text/batch/language-identification)              | Batch           | SaaS          |
 | [Notifications](/speech-to-text/batch/notifications.md)                               | Batch           | SaaS, On-prem |
-| [Numeral formatting](/speech-to-text/formatting#smart-formatting)                     | Batch, Realtime | SaaS, On-prem |
 | [Punctuation settings](/speech-to-text/formatting#punctuation)                        | Batch, Realtime | SaaS, On-prem |
 | [Sentiment analysis](/speech-to-text/batch/speech-intelligence/sentiment-analysis)    | Batch           | SaaS, On-prem |
+| [Smart formatting](/speech-to-text/formatting#smart-formatting)                       | Batch, Realtime | SaaS, On-prem |
 | [Speaker identification](/speech-to-text/features/speaker-identification)             | Batch, Realtime | SaaS, On-prem |
 | [Summarization](/speech-to-text/batch/speech-intelligence/summarization)              | Batch           | SaaS          |
 | [Topic detection](/speech-to-text/batch/speech-intelligence/topic-detection)          | Batch           | SaaS          |

--- a/docs/speech-to-text/formatting.mdx
+++ b/docs/speech-to-text/formatting.mdx
@@ -5,6 +5,7 @@ keywords:
     numeral formatting,
     output formatting,
     punctuation,
+    smart formatting,
     transcript format,
     transcription
   ]
@@ -221,13 +222,15 @@ Word replacement rules:
 
 ## Smart formatting
 
-Speechmatics automatically converts spoken numbers, dates, currencies, and other entities into properly formatted text. This makes transcripts more readable without losing timing information.
+Smart formatting converts spoken numbers, dates, currencies, and other entities into properly formatted text. This makes transcripts more readable without losing timing information.
 
-For example, spoken words like "nineteen ninety nine" become "1999" in the output.
+An *entity* is a spoken value that has a conventional written form, such as a number, date, currency, time, or measurement. Speechmatics detects each entity and converts it from the words as spoken into its written form. For example, the spoken words "nineteen ninety nine" become "1999" in the output.
+
+Smart formatting is applied by default. Set `enable_entities` to `true` to also expose the structure of each entity in the JSON output: the class of entity, and the individual spoken and written words it is made from.
 
 ### Configuration
 
-To include detailed information about entities in your JSON output, add this to your configuration:
+To include detailed entity information in your JSON output, add `enable_entities` to your configuration:
 
 ```json
 {
@@ -351,7 +354,7 @@ Examples:
 - **German**: Uses periods for thousands (20.000), commas for decimals (10,5), and places currency symbols after values with a non-breaking space (10 $)
 - **French**: Uses non-breaking spaces for thousands (20 000), commas for decimals (10,5), and places currency symbols after values with a non-breaking space (10 $)
 
-Smart formatting is available in these languages:
+Smart formatting has had dedicated work for consistent results in these languages:
 
 - Cantonese
 - Chinese Mandarin (Simplified and Traditional)
@@ -370,6 +373,10 @@ Smart formatting is available in these languages:
 - Spanish
 - Swedish
 - Tamil & English (bilingual)
+
+Other languages still format numbers and entities on a best-effort basis through the model, with variable results. If you rely on formatting for a language that isn't listed, test it with representative audio rather than assuming full coverage.
+
+Formatting coverage isn't reported by [feature discovery](/speech-to-text/features/feature-discovery), which covers transcription, translation, and language identification. This page is the reference for formatting language support.
 
 ## Punctuation
 

--- a/docs/speech-to-text/realtime/output.mdx
+++ b/docs/speech-to-text/realtime/output.mdx
@@ -38,7 +38,7 @@ The following example shows a typical configuration for low latency applications
 ```
 
 - `max_delay` (Number): Optional. Allowed between 0.7 and 4 seconds. Default is 4 seconds. This is the delay in seconds between the end of a spoken word and returning the Final transcript results. Note that there is a very small amount of additional latency while the server is sending the transcript to the client.
-- `max_delay_mode` (String): Optional. Allowed values are `fixed` and `flexible`. Default is `flexible`. This allows some additional time for [Numeral Formatting](#smart-formatting).
+- `max_delay_mode` (String): Optional. Allowed values are `fixed` and `flexible`. Default is `flexible`. This allows some additional time for [Smart formatting](#smart-formatting).
 - `enable_partials` (Boolean): Default is false. Whether or not to receive [Partial transcripts](#partial-transcripts) before the Final transcripts are received.
 
 ## Accuracy/Latency trade-offs
@@ -79,7 +79,7 @@ Note that Partial transcripts have some limitations:
 
 ## Smart formatting
 
-[Smart Formatting](/speech-to-text/formatting#smart-formatting) ensures readability of your transcripts by formatting numbers, dates, currencies and other important _entities_ into their written form.
+[Smart formatting](/speech-to-text/formatting#smart-formatting) ensures readability of your transcripts by formatting numbers, dates, currencies and other important _entities_ into their written form.
 
 When the `max_delay_mode` is set to `flexible`, and an entity is being spoken, the Final transcript would be delayed until the entity is fully spoken to enable proper formatting. This option should be used in most use-cases for improved accuracy and readability for numbers, currencies, and dates. 
 


### PR DESCRIPTION
## What

Resolves the Smart formatting / entity / "numeral formatting" confusion in the docs, and clarifies smart formatting language coverage.

Covers **[DEL-33629](https://speechmatics.atlassian.net/browse/DEL-33629)** (terminology + entity concept) and the doc-facing part of **[DEL-33895](https://speechmatics.atlassian.net/browse/DEL-33895)** (language coverage / off-list behaviour).

## Changes

- **`docs/speech-to-text/formatting.mdx`**
  - Added a plain-language definition of an **entity** (a spoken value with a conventional written form).
  - Clarified `enable_entities`: smart formatting is applied by default; the option *additionally* exposes each entity's structure (`entity_class`, `spoken_form`, `written_form`) in the JSON output.
  - Reframed the language list from "available in these languages" to **languages with dedicated formatting work for consistency**, and added a best-effort note for off-list languages, a testing caveat, and a note that formatting coverage is not reported by feature discovery.
  - Added `smart formatting` to the page keywords (kept `numeral formatting` as hidden search metadata).
- **`docs/deployments/index.md`** — renamed the feature-availability row **"Numeral formatting" → "Smart formatting"** (link already pointed at `#smart-formatting`) and moved it into alphabetical order.
- **`docs/speech-to-text/realtime/output.mdx`** — `Numeral Formatting` → `Smart formatting`, and fixed `Smart Formatting` casing to sentence case.
- **`.CLAUDE/context/terminology.md`** — added canonical **smart formatting** and **entity** entries; flagged "numeral formatting" as too narrow.

The JSON output description in the story (`type: entity`, `content`, `entity_class`, start/end times, `spoken_form`, `written_form`) already existed on `main`, so that section was left intact.

## Out of scope

The investigation items in DEL-33895 — confirming the authoritative language list, whether support is all-or-nothing vs per entity class, why Romanian/Turkish/Arabic behave as they do off-list, and whether formatting coverage should be added to feature discovery — are product-team research items and are not resolved here. The docs only reframe the existing list and add the best-effort caveat.

## Verification

- Full `docusaurus build` passes with `onBrokenLinks: "throw"` — no broken links or anchors introduced.
- `cspell` clean on the changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
