### PR TITLE
Add default model and language to STT code samples

### DIFF
--- a/docs/speech-to-text/batch/assets/speechmatics-batch-quickstart.py
+++ b/docs/speech-to-text/batch/assets/speechmatics-batch-quickstart.py
@@ -5,7 +5,7 @@ API_KEY = "YOUR_API_KEY"
 AUDIO_FILE= "example.wav"
 
 config = TranscriptionConfig(
-    diarization="speaker"
+    language="en",
     model="enhanced"
 )
 

--- a/docs/speech-to-text/batch/assets/speechmatics-batch-quickstart.py
+++ b/docs/speech-to-text/batch/assets/speechmatics-batch-quickstart.py
@@ -5,6 +5,7 @@ API_KEY = "YOUR_API_KEY"
 AUDIO_FILE= "example.wav"
 
 config = TranscriptionConfig(
+    diarization="speaker",
     language="en",
     model="enhanced"
 )

--- a/docs/speech-to-text/batch/notifications.md
+++ b/docs/speech-to-text/batch/notifications.md
@@ -48,7 +48,8 @@ Below are examples of a configuration that requests a `JSON-v2` transcript and t
 {
   "type": "transcription",
   "transcription_config": {
-    "language": "en"
+    "language": "en",
+    "model": "enhanced"
   },
   "notification_config": [
     {

--- a/docs/speech-to-text/batch/speaker-identification.mdx
+++ b/docs/speech-to-text/batch/speaker-identification.mdx
@@ -34,7 +34,7 @@ You can request the identifiers back from the engine by setting the `get_speaker
   "transcription_config": {
     "model": "enhanced",
     "language": "en",
-    "diarization": "speaker"
+    "diarization": "speaker",
     "speaker_diarization_config": {
       // highlight-start
       "get_speakers": true

--- a/docs/speech-to-text/batch/speech-intelligence/assets/auto-chapters.py
+++ b/docs/speech-to-text/batch/speech-intelligence/assets/auto-chapters.py
@@ -14,7 +14,7 @@ settings = ConnectionSettings(
 # Define transcription parameters
 conf = {
     "type": "transcription",
-    "transcription_config": {"language": LANGUAGE},
+    "transcription_config": {"language": LANGUAGE, "model": "enhanced"},
     # highlight-start
     "auto_chapters_config": {},
     # highlight-end

--- a/docs/speech-to-text/batch/speech-intelligence/assets/sentiment.py
+++ b/docs/speech-to-text/batch/speech-intelligence/assets/sentiment.py
@@ -14,7 +14,7 @@ settings = ConnectionSettings(
 # Define transcription parameters
 conf = {
     "type": "transcription",
-    "transcription_config": {"language": LANGUAGE},
+    "transcription_config": {"language": LANGUAGE, "model": "enhanced"},
     # highlight-start
     "sentiment_analysis_config": {},
     # highlight-end

--- a/docs/speech-to-text/batch/speech-intelligence/assets/summarization.py
+++ b/docs/speech-to-text/batch/speech-intelligence/assets/summarization.py
@@ -14,7 +14,7 @@ settings = ConnectionSettings(
 # Define transcription parameters
 conf = {
     "type": "transcription",
-    "transcription_config": {"language": LANGUAGE},
+    "transcription_config": {"language": LANGUAGE, "model": "enhanced"},
     # highlight-start
     "summarization_config": {},  # You can also configure the summary. See below for more detail.
     # highlight-end

--- a/docs/speech-to-text/batch/speech-intelligence/assets/topics.py
+++ b/docs/speech-to-text/batch/speech-intelligence/assets/topics.py
@@ -14,7 +14,7 @@ settings = ConnectionSettings(
 # Define transcription parameters
 conf = {
     "type": "transcription",
-    "transcription_config": {"language": LANGUAGE},
+    "transcription_config": {"language": LANGUAGE, "model": "enhanced"},
     # highlight-start
     # You can also configure the list of topics you wish to detect. See below for more detail.
     "topic_detection_config": {},

--- a/docs/speech-to-text/features/translation.mdx
+++ b/docs/speech-to-text/features/translation.mdx
@@ -197,7 +197,8 @@ settings = ConnectionSettings(
 conf = {
     "type": "transcription",
     "transcription_config": {
-        "language": LANGUAGE
+        "language": LANGUAGE,
+        "model": "enhanced"
     },
     "translation_config": {
         "target_languages":TRANSLATION_LANGUAGES
@@ -292,6 +293,7 @@ translation_config = speechmatics.models.RTTranslationConfig(
 )
 
 transcription_config = speechmatics.models.TranscriptionConfig(
+    model="enhanced",
     language=LANGUAGE,
     translation_config=translation_config
 )

--- a/docs/speech-to-text/languages.mdx
+++ b/docs/speech-to-text/languages.mdx
@@ -148,6 +148,7 @@ This config selects the Mandarin and English pack:
 {
   "type": "transcription",
   "transcription_config": {
+    "model": "enhanced",
     "language": "cmn_en"
   }
 }
@@ -159,6 +160,7 @@ This config selects the Spanish and English pack, which requires the `domain` pr
 {
   "type": "transcription",
   "transcription_config": {
+    "model": "enhanced",
     "language": "es",
     "domain": "bilingual-en"
   }

--- a/docs/speech-to-text/realtime/assets/sm-rt-example.py
+++ b/docs/speech-to-text/realtime/assets/sm-rt-example.py
@@ -14,7 +14,8 @@ audio_format = AudioFormat(
     chunk_size=4096,
 )
 config = TranscriptionConfig(
-    language="en", 
+    model="enhanced",
+    language="en",
     max_delay=0.7,
 )
 

--- a/docs/speech-to-text/realtime/assets/speaker-id-enrollment-file-example.py
+++ b/docs/speech-to-text/realtime/assets/speaker-id-enrollment-file-example.py
@@ -16,6 +16,7 @@ async def enroll_speakers():
     handler_tasks: list[asyncio.Task] = []
 
     transcription_config = speechmatics.models.TranscriptionConfig(**{
+            "model": "enhanced",
             "language": LANGUAGE,
             "diarization": "speaker",
         }

--- a/docs/speech-to-text/realtime/assets/speaker-id-identification-file-example.py
+++ b/docs/speech-to-text/realtime/assets/speaker-id-identification-file-example.py
@@ -13,6 +13,7 @@ async def identify_speakers():
     handler_tasks: list[asyncio.Task] = []
 
     transcription_config = speechmatics.models.TranscriptionConfig(**{
+            "model": "enhanced",
             "language": LANGUAGE,
             "diarization": "speaker",
             "speaker_diarization_config": {

--- a/docs/speech-to-text/realtime/realtime-diarization.mdx
+++ b/docs/speech-to-text/realtime/realtime-diarization.mdx
@@ -49,6 +49,7 @@ To enable Speaker diarization, `diarization` must be set to `speaker` in the tra
 {
   "type": "transcription",
   "transcription_config": {
+    "model": "enhanced",
     "language": "en",
     // highlight-start
     "diarization": "speaker"
@@ -100,6 +101,7 @@ To enable channel diarization, `diarization` must be set to `channel` and labels
 {
   "type": "transcription",
   "transcription_config": {
+    "model": "enhanced",
     "language": "en",
     // highlight-start
     "diarization": "channel",
@@ -257,6 +259,7 @@ You can configure the sensitivity of speaker detection by using the `speaker_sen
 {
   "type": "transcription",
   "transcription_config": {
+    "model": "enhanced",
     "language": "en",
     // highlight-start
     "diarization": "speaker",
@@ -279,6 +282,7 @@ You can reduce the likelihood of incorrectly switching between similar sounding 
 {
   "type": "transcription",
   "transcription_config": {
+    "model": "enhanced",
     "language": "en",
     // highlight-start
     "diarization": "speaker",

--- a/docs/speech-to-text/realtime/speaker-identification.mdx
+++ b/docs/speech-to-text/realtime/speaker-identification.mdx
@@ -56,7 +56,7 @@ Example speaker diarization config:
   "transcription_config": {
     "model": "enhanced",
     "language": "en",
-    "diarization": "speaker"
+    "diarization": "speaker",
     "speaker_diarization_config": {
       // highlight-start
       "get_speakers": true


### PR DESCRIPTION
- Ensure `transcription_config` examples across batch and realtime docs (inline snippets and asset files) define model="enhanced", diarization="speaker", and language="en" by default
- Preserve intentional overrides (language auto/multi, channel diarization, showcased models)
- Leave response/metadata examples untouched
- Also fixes several pre-existing JSON syntax errors (missing commas) and a missing language in the batch quickstart.