### PR TITLE
Address Smart formatting review feedback (#286): trim wording, note Melia entity gap

### DIFF
--- a/docs/speech-to-text/formatting.mdx
+++ b/docs/speech-to-text/formatting.mdx
@@ -245,6 +245,10 @@ To include detailed entity information in your JSON output, add `enable_entities
 
 By default, `enable_entities` is `false`. When enabled, entity metadata appears only in JSON output (SRT and TXT formats remain unchanged).
 
+:::note
+Entity output (`enable_entities` and the `spoken_form` and `written_form` representations) is available with the Standard and Enhanced models. The Melia 1 multilingual model does not support entity detection yet; see [Models](/speech-to-text/models).
+:::
+
 ### Output
 
 The JSON output will include:
@@ -374,7 +378,7 @@ Smart formatting has had dedicated work for consistent results in these language
 - Swedish
 - Tamil & English (bilingual)
 
-Other languages still format numbers and entities on a best-effort basis through the model, with variable results. If you rely on formatting for a language that isn't listed, test it with representative audio rather than assuming full coverage.
+Other languages still format numbers and entities on a best-effort basis through the model. If you rely on formatting for a language that isn't listed, test it with representative audio rather than assuming full coverage.
 
 Formatting coverage isn't reported by [feature discovery](/speech-to-text/features/feature-discovery), which covers transcription, translation, and language identification. This page is the reference for formatting language support.
 


### PR DESCRIPTION
## What

Follow-up to the review feedback from @stuartw843 on #286 (merged).

- **Drops "with variable results"** from the off-list languages note — "best-effort" already conveys the variability (addresses [this comment](https://github.com/speechmatics/docs/pull/286#discussion_r3560182805)).
- **Adds a model-support note** clarifying that entity output (`enable_entities`, `spoken_form`/`written_form`) is available with the **Standard and Enhanced** models, and links to the Melia 1 feature gap in [Models](https://docs.speechmatics.com/speech-to-text/models). This is accurate per `models.mdx`, which already lists "spoken form output" and "entity detection" among the features Melia 1 does not yet support.

## Deferred (not in this PR)

Stuart's broader point — that under Melia the page should say **smart formatting is on by default for all languages** and drop `enable_entities` / spoken & written form entirely — is a forward-looking rewrite. It isn't accurate today: Standard and Enhanced are still the primary models (Realtime + Batch) and fully support entity output, and Melia 1 is Batch-only and early-access. That rewrite is tracked in **[DEL-34274](https://speechmatics.atlassian.net/browse/DEL-34274)**, to land when Melia is the default/GA and the wording is confirmed with engineering.

## Verification

- Full `docusaurus build` passes with `onBrokenLinks: "throw"` — the new `:::note` compiles and the `/speech-to-text/models` link resolves.
