### PR TITLE
Use "Mandarin" not "Chinese Mandarin" in formatting docs (#289 follow-up)

### DIFF
--- a/.CLAUDE/context/terminology.md
+++ b/.CLAUDE/context/terminology.md
@@ -89,6 +89,7 @@ Speechmatics does not sell a "voice agent." A voice agent is a full conversation
 | SDK | sdk | All-caps. |
 | job | Job | Lowercase common noun. |
 | transcript | Transcript | Lowercase unless starting a sentence. |
+| Mandarin | Chinese Mandarin, Mandarin Chinese | Language name, matching the canonical row on the languages page (`cmn`). Locale names are "Simplified Mandarin" (`cmn-Hans`) and "Traditional Mandarin" (`cmn-Hant`). |
 
 ---
 

--- a/docs/speech-to-text/formatting.mdx
+++ b/docs/speech-to-text/formatting.mdx
@@ -37,7 +37,7 @@ Available English locales:
 - US English (`en-US`)
 - Australian English (`en-AU`)
 
-Available Chinese Mandarin locales:
+Available Mandarin locales:
 - Simplified Mandarin (`cmn-Hans`, default)
 - Traditional Mandarin (`cmn-Hant`)
 
@@ -152,7 +152,6 @@ uum`}
 Disfluency tagging and removal are available for the following languages. Each language has its own set of hesitation sounds; the expandable list at the start of this section covers English.
 
 - Arabic (`ar`)
-- Chinese Mandarin (`cmn`)
 - Danish (`da`)
 - Dutch (`nl`)
 - English (`en`)
@@ -165,6 +164,7 @@ Disfluency tagging and removal are available for the following languages. Each l
 - Hungarian (`hu`)
 - Italian (`it`)
 - Japanese (`ja`)
+- Mandarin (`cmn`)
 - Norwegian (`no`)
 - Polish (`pl`)
 - Portuguese (`pt`)
@@ -384,7 +384,6 @@ Examples:
 Smart formatting has had dedicated work for consistent results in these languages:
 
 - Cantonese
-- Chinese Mandarin (Simplified and Traditional)
 - Dutch
 - English
 - French
@@ -392,6 +391,7 @@ Smart formatting has had dedicated work for consistent results in these language
 - Hindi
 - Italian
 - Japanese
+- Mandarin (Simplified and Traditional)
 - Mandarin & English (bilingual)
 - Mandarin Malay Tamil & English (multilingual)
 - Norwegian


### PR DESCRIPTION
Follow-up agreed in the #289 review (with @giorgosHadji): the docs should use **"Mandarin"** everywhere, not "Chinese Mandarin", matching the canonical row on the languages page (`Mandarin | cmn`).

Targeting `feature/disfluency` so it rides in with #289.

## Changes

**`docs/speech-to-text/formatting.mdx`** — the three "Chinese Mandarin" occurrences:
- "Available Chinese Mandarin locales:" → "Available Mandarin locales:"
- Disfluency supported-languages list: "Chinese Mandarin (`cmn`)" → "Mandarin (`cmn`)", moved to its alphabetical position (M)
- Smart formatting languages list: "Chinese Mandarin (Simplified and Traditional)" → "Mandarin (Simplified and Traditional)", also moved to M

**`.CLAUDE/context/terminology.md`** — records "Mandarin" as the canonical form ("Chinese Mandarin"/"Mandarin Chinese" in the do-not-use column). This is assistant-context, not deployed site content.

## Checks
- Repo-wide grep (`docs/`, `spec/`, `src/`) — no other "Chinese Mandarin" occurrences remain
- cspell on the changed file: 0 issues
- No headings changed, so no internal anchors break

🤖 Generated with [Claude Code](https://claude.com/claude-code)