### PR TITLE
Hotfix: fix missing letter in Zapier header

### DIFF
--- a/docs/integrations-and-sdks/zapier.mdx
+++ b/docs/integrations-and-sdks/zapier.mdx
@@ -1,6 +1,6 @@
 ---
 title: Zapier integration
-description: ranscribe audio in your Zapier workflow - no code required.
+description: Transcribe audio in your Zapier workflow - no code required.
 ---
 
 # Zapier integration


### PR DESCRIPTION
This change adds a missing T to the Zapier integration page header.