### PR TITLE
Document all-languages GPU image and SM_LANGUAGES for Container 15.18.0

### DIFF
--- a/docs/deployments/container/accessing-images.mdx
+++ b/docs/deployments/container/accessing-images.mdx
@@ -120,7 +120,7 @@ Depending on which Enhanced model languages are required, you can pull specific 
 
 ### Standard and Enhanced model
 
-A single image supports all languages for both the Standard and Enhanced models, so you do not need to pull individual language pack images.
+A single image supports all languages for both the Standard and Enhanced models, so you do not need to pull individual language pack images. The `sm-gpu-inference-server-standard-all` image above covers all languages for the Standard model only.
 
 <CodeBlock language="bash">
   {`# pulling the Transcription GPU inference server supporting all languages for both Enhanced and Standard models with the ${smVariables.latestContainerVersion} tag:

--- a/docs/deployments/container/accessing-images.mdx
+++ b/docs/deployments/container/accessing-images.mdx
@@ -78,7 +78,7 @@ docker pull speechmaticspublic.azurecr.io/sm-gpu-inference-server-en:${smVariabl
 
 ### Enhanced model
 
-Depending on which Enhanced model languages are required, you can pull specific images.
+Depending on which Enhanced model languages are required, you can pull specific images, or a single image covering all languages.
 
 <details open>
   <summary>Language Pack 1</summary>
@@ -111,6 +111,16 @@ Depending on which Enhanced model languages are required, you can pull specific 
     {`docker pull speechmaticspublic.azurecr.io/sm-gpu-inference-server-enhanced-recipe4:${smVariables.latestContainerVersion} `}
   </CodeBlock>
 </details>
+
+<details open>
+  <summary>All languages</summary>
+  <p>All Enhanced and Standard model languages</p>
+  <CodeBlock language="bash">
+    {`docker pull speechmaticspublic.azurecr.io/sm-gpu-inference-server-all-lang:${smVariables.latestContainerVersion} `}
+  </CodeBlock>
+</details>
+
+To load only some of an image's languages at startup, see [Loading only selected languages](/deployments/container/gpu-speech-to-text#loading-only-selected-languages).
 
 See [how to run the Transcription GPU container here.](/deployments/container/gpu-speech-to-text)
 

--- a/docs/deployments/container/accessing-images.mdx
+++ b/docs/deployments/container/accessing-images.mdx
@@ -64,6 +64,12 @@ See [how to run the Core Speech CPU container here.](/deployments/container/cpu-
 
 The Transcription GPU images are required to use the most accurate models.
 
+See [how to run the Transcription GPU container here.](/deployments/container/gpu-speech-to-text)
+
+:::info
+To access additional language configurations for containers, please [speak to our Support Team](https://support.speechmatics.com).
+:::
+
 ### Standard model
 
 There is a single image available that supports all languages for the Standard model. There are language specific images available that support the Enhanced and Standard models.
@@ -78,7 +84,7 @@ docker pull speechmaticspublic.azurecr.io/sm-gpu-inference-server-en:${smVariabl
 
 ### Enhanced model
 
-Depending on which Enhanced model languages are required, you can pull specific images, or a single image covering all languages.
+Depending on which Enhanced model languages are required, you can pull specific images.
 
 <details open>
   <summary>Language Pack 1</summary>
@@ -112,21 +118,16 @@ Depending on which Enhanced model languages are required, you can pull specific 
   </CodeBlock>
 </details>
 
-<details open>
-  <summary>All languages</summary>
-  <p>All Enhanced and Standard model languages</p>
-  <CodeBlock language="bash">
-    {`docker pull speechmaticspublic.azurecr.io/sm-gpu-inference-server-all-lang:${smVariables.latestContainerVersion} `}
-  </CodeBlock>
-</details>
+### Standard and Enhanced model
 
-To load only some of an image's languages at startup, see [Loading only selected languages](/deployments/container/gpu-speech-to-text#loading-only-selected-languages).
+A single image supports all languages for both the Standard and Enhanced models, so you do not need to pull individual language pack images.
 
-See [how to run the Transcription GPU container here.](/deployments/container/gpu-speech-to-text)
+<CodeBlock language="bash">
+  {`# pulling the Transcription GPU inference server supporting all languages for both Enhanced and Standard models with the ${smVariables.latestContainerVersion} tag:
+docker pull speechmaticspublic.azurecr.io/sm-gpu-inference-server-all-lang:${smVariables.latestContainerVersion}`}
+</CodeBlock>
 
-:::info
-To access additional language configurations for containers, please [speak to our Support Team](https://support.speechmatics.com).
-:::
+This image contains both models. To load only one of them, see [Running only one model](/deployments/container/gpu-speech-to-text#running-only-one-model). To load only some of the image's languages, see [Loading only selected languages](/deployments/container/gpu-speech-to-text#loading-only-selected-languages).
 
 ### Melia 1 model
 

--- a/docs/deployments/container/gpu-speech-to-text.mdx
+++ b/docs/deployments/container/gpu-speech-to-text.mdx
@@ -119,7 +119,7 @@ When running the all language standard model GPU inference server you must set t
 
 ### Loading only selected languages
 
-Images that contain more than one language model, such as the [all language images](/deployments/container/accessing-images#enhanced-model), load every language at startup. To save GPU memory for throughput, pass the `SM_LANGUAGES` environment variable to the container and set it to a comma-separated list of language codes. Only those languages are loaded:
+Images that contain more than one language model load every language at startup. To save GPU memory for throughput, pass the `SM_LANGUAGES` environment variable to the container and set it to a comma-separated list of language codes. Only those languages are loaded:
 
 ```bash
 -e SM_LANGUAGES=en,de,fr
@@ -128,6 +128,8 @@ Images that contain more than one language model, such as the [all language imag
 Codes must be languages the image contains. A code the image does not contain fails startup with an error.
 
 When `SM_LANGUAGES` is unset, all of the image's languages are loaded. `SM_LANGUAGES` is available from Container version 15.18.0.
+
+`SM_LANGUAGES` and `SM_MODEL` can be combined to trim both axes of the startup load. For example, `SM_MODEL=standard` with `SM_LANGUAGES=en,de` loads the Standard model for English and German only.
 
 ### Monitoring the server
 

--- a/docs/deployments/container/gpu-speech-to-text.mdx
+++ b/docs/deployments/container/gpu-speech-to-text.mdx
@@ -117,6 +117,18 @@ To save GPU memory for throughput, you can run the server with only one model lo
 When running the all language standard model GPU inference server you must set the `SM_MODEL` environment variable to `standard`
 :::
 
+### Loading only selected languages
+
+Images that contain more than one language model, such as the [all language images](/deployments/container/accessing-images#enhanced-model), load every language at startup. To save GPU memory for throughput, pass the `SM_LANGUAGES` environment variable to the container and set it to a comma-separated list of language codes. Only those languages are loaded:
+
+```bash
+-e SM_LANGUAGES=en,de,fr
+```
+
+Codes must be languages the image contains. A code the image does not contain fails startup with an error.
+
+When `SM_LANGUAGES` is unset, all of the image's languages are loaded. `SM_LANGUAGES` is available from Container version 15.18.0.
+
 ### Monitoring the server
 
 The inference server is based on [Nvidia's Triton architecture](https://developer.nvidia.com/nvidia-triton-inference-server) and as such

--- a/docs/deployments/container/gpu-speech-to-text.mdx
+++ b/docs/deployments/container/gpu-speech-to-text.mdx
@@ -122,14 +122,15 @@ When running the all language standard model GPU inference server you must set t
 Images that contain more than one language model load every language at startup. To save GPU memory for throughput, pass the `SM_LANGUAGES` environment variable to the container and set it to a comma-separated list of language codes. Only those languages are loaded:
 
 ```bash
+# load only English, German, and French
 -e SM_LANGUAGES=en,de,fr
 ```
 
-Codes must be languages the image contains. A code the image does not contain fails startup with an error.
+Codes must be languages the image contains. Any code the image does not contain causes startup to fail with an error.
 
-When `SM_LANGUAGES` is unset, all of the image's languages are loaded. `SM_LANGUAGES` is available from Container version 15.18.0.
+When `SM_LANGUAGES` is unset, all of the image's languages are loaded. `SM_LANGUAGES` is available from container version 15.18.0.
 
-`SM_LANGUAGES` and `SM_MODEL` can be combined to trim both axes of the startup load. For example, `SM_MODEL=standard` with `SM_LANGUAGES=en,de` loads the Standard model for English and German only.
+`SM_LANGUAGES` and `SM_MODEL` can be used together. For example, `SM_MODEL=standard` with `SM_LANGUAGES=en,de` loads the Standard model for English and German only.
 
 ### Monitoring the server
 

--- a/docs/deployments/container/performance-and-cost.mdx
+++ b/docs/deployments/container/performance-and-cost.mdx
@@ -24,15 +24,15 @@ This is a comparison of the performance and estimated running costs of transcrip
 
 The benchmark uses the following configuration:
 
-| Benchmark details |                                               |
-|-------------------|-----------------------------------------------|
-| Version           | 15.18.0 (Standard, Enhanced), 1.3.0 (Melia-1) |
-| Language          | English only                                  |
-| CPU               | D16ds_v5                                      |
-| GPU Standard      | Standard_NC16as_T4_v3                         |
-| GPU Enhanced      | Standard_NC8as_T4_v3                          |
-| GPU Melia-1       | Standard_NC40ads_H100_v5                      |
-| Price Basis       | Azure PAYG East US, Linux, Standard           |
+| Benchmark details |                                              |
+|-------------------|----------------------------------------------|
+| Version           | 15.7.0 (Standard, Enhanced), 1.3.0 (Melia-1) |
+| Language          | English only                                 |
+| CPU               | D16ds_v5                                     |
+| GPU Standard      | Standard_NC16as_T4_v3                        |
+| GPU Enhanced      | Standard_NC8as_T4_v3                         |
+| GPU Melia-1       | Standard_NC40ads_H100_v5                     |
+| Price Basis       | Azure PAYG East US, Linux, Standard          |
 
 :::note
 For GPU Models, transcribers and inference servers were all run on a single VM node.

--- a/docs/deployments/container/performance-and-cost.mdx
+++ b/docs/deployments/container/performance-and-cost.mdx
@@ -24,14 +24,15 @@ This is a comparison of the performance and estimated running costs of transcrip
 
 The benchmark uses the following configuration:
 
-| Benchmark details |                                              |
-|-------------------|----------------------------------------------|
-| Version           | 15.7.0 (Standard, Enhanced), 1.3.0 (Melia-1) |
-| CPU               | D16ds_v5                                     |
-| GPU Standard      | Standard_NC16as_T4_v3                        |
-| GPU Enhanced      | Standard_NC8as_T4_v3                         |
-| GPU Melia-1       | Standard_NC40ads_H100_v5                     |
-| Price Basis       | Azure PAYG East US, Linux, Standard          |
+| Benchmark details |                                               |
+|-------------------|-----------------------------------------------|
+| Version           | 15.18.0 (Standard, Enhanced), 1.3.0 (Melia-1) |
+| Language          | English only                                  |
+| CPU               | D16ds_v5                                      |
+| GPU Standard      | Standard_NC16as_T4_v3                         |
+| GPU Enhanced      | Standard_NC8as_T4_v3                          |
+| GPU Melia-1       | Standard_NC40ads_H100_v5                      |
+| Price Basis       | Azure PAYG East US, Linux, Standard           |
 
 :::note
 For GPU Models, transcribers and inference servers were all run on a single VM node.
@@ -54,6 +55,7 @@ This benchmark uses the following configuration[^4]:
 | Benchmark details | Value                               |
 | ------------------| ----------------------------------- |
 | Version           | 13.4.0                              |
+| Language          | English only                        |
 | CPU               | D16ds_v5                            |
 | GPU Standard      | Standard_NC16as_T4_v3               |
 | GPU Enhanced      | Standard_NC8as_T4_v3                |

--- a/sm-variables.ts
+++ b/sm-variables.ts
@@ -1,7 +1,7 @@
 export const smVariables = {
   jsonOutputVersion: "2.9",
   latestApplianceVersion: "6.3.0",
-  latestContainerVersion: "15.14.0",
+  latestContainerVersion: "15.18.0",
   latestMelia1ContainerVersion: "1.3.0",
   usageContainerVersion: "0.3.0",
   helmChartVersion: "1.4.0",


### PR DESCRIPTION
- Add an All languages option for sm-gpu-inference-server-all-lang under the Enhanced model section, and note it in the section intro
- Document SM_LANGUAGES on the GPU inference server, including the unset default and the startup failure on an unrecognised code
- Bump latestContainerVersion to 15.18.0
- Record English-only language configuration in both benchmark tables.