### PR TITLE
Document combining SM_EATS_URL and SM_ENABLE_USAGE_REPORTING

### DIFF
--- a/docs/deployments/usage-reporting/automatic.mdx
+++ b/docs/deployments/usage-reporting/automatic.mdx
@@ -66,6 +66,8 @@ To enable automatic usage reporting, you must be running one of the following AS
 
 Automatic usage reporting is turned ON by default, starting from version `10.6.0`.
 
+`SM_EATS_URL` overrides the destination for these reports. Set it to redirect automatic reporting to your own [Usage Container](/deployments/usage-reporting/offline#container) instead of `usage.speechmatics.com`, without changing which events are sent. See [Offline usage reporting](/deployments/usage-reporting/offline) for details.
+
 ### Virtual appliance
 
 For virtual appliances, automatic usage reporting is turned ON by default and is currently opt out.

--- a/docs/deployments/usage-reporting/index.mdx
+++ b/docs/deployments/usage-reporting/index.mdx
@@ -25,6 +25,12 @@ For on-prem deployments, usage reporting is required for accurate billing. There
   />
 </Grid>
 
+## How the reporting mode is configured
+
+Both modes are controlled by the same two settings. `SM_EATS_URL` sets the destination for usage events; if it is not set, the transcriber falls back to `usage.speechmatics.com`. `SM_ENABLE_USAGE_REPORTING` sets whether the transcriber restricts events to the subset needed for billing (`true`, the default) or sends the full activity event stream (`false`).
+
+Automatic reporting relies on the default destination, with `SM_ENABLE_USAGE_REPORTING` left at its default of `true`. Offline reporting sets `SM_EATS_URL` to your own [Usage Container](/deployments/usage-reporting/offline#container) instead, while `SM_ENABLE_USAGE_REPORTING` remains at its default — the same billing events are sent to your container rather than to Speechmatics.
+
 ## What data do we record?
 
 :::info

--- a/docs/deployments/usage-reporting/offline.mdx
+++ b/docs/deployments/usage-reporting/offline.mdx
@@ -276,6 +276,8 @@ The following configuration options **must** be specified when running the ASR C
 
 To correctly configure the transcriber, set `SM_EATS_URL` environment variable to point to ASR Usage Container. e.g., `SM_EATS_URL=asr-usage.example.net:9090` or `SM_EATS_URL=10.244.8.32:9090`, where `asr-usage.example.net` and `10.244.8.32` correspond to the relevant ASR Usage Container instance. The port `9090` is the default listening port for incoming data from transcribers. The port number is alterable by using the `EATS_PORT` environment variable.
 
+`SM_EATS_URL` can be set alongside `SM_ENABLE_USAGE_REPORTING` — leave `SM_ENABLE_USAGE_REPORTING` at its default of `true` so the transcriber sends the same billing events described in [Automatic usage reporting](/deployments/usage-reporting/automatic#technical-details) to your Usage Container instead of to Speechmatics.
+
 Below is a working example of running an ASR Batch Container that will then send transcription event data to a running ASR Usage Container:
 
 ```bash


### PR DESCRIPTION
Clarify the two settings can be used together to redirect automatic reporting to a local Usage Container.